### PR TITLE
Update Read to ensure STAR STAR matrices are broadcast after read

### DIFF
--- a/src/io/Read.cpp
+++ b/src/io/Read.cpp
@@ -54,7 +54,7 @@ void Read
     if( format == AUTO )
         format = DetectFormat( filename );
 
-    if( A.ColStride() == 1 && A.RowStride() == 1 )
+    if(( A.ColStride() == 1 && A.RowStride() == 1 ) && !(A.ColDist() == STAR || A.RowDist() == STAR))
     {
         if( A.CrossRank() == A.Root() && A.RedundantRank() == 0 )
         {


### PR DESCRIPTION
"For general case, Elemental's serial IO relies on converting a distributed matrix to/from a circle matrix before/after IO. Elemental attempts performance optimization for the case with Circ-Circ, Star-Star, or any type matrix if serial. However, in case of Star-Star matrices we need bcast (or scatter) after manually filling the local buffer from reading file."

