### PR TITLE
Don't disrupt matrix views during resizing if possible.

### DIFF
--- a/include/El/core/AbstractMatrix.hpp
+++ b/include/El/core/AbstractMatrix.hpp
@@ -268,8 +268,13 @@ template <typename T>
 inline void AbstractMatrix<T>::Resize_(
     Int height, Int width, Int leadingDimension)
 {
-    this->SetSize_(height, width, leadingDimension);
-    do_resize_();
+    if (height != this->Height()
+        || width != this->Width()
+        || leadingDimension != this->LDim())
+    {
+        this->SetSize_(height, width, leadingDimension);
+        do_resize_();
+    }
 }
 
 template <typename T>


### PR DESCRIPTION
If a matrix resize doesn't require changing the height, width, or leading dimension, do nothing. This fixes a bug where we weren't able to copy into matrix views.