### PR TITLE
Handling case when Hydrogen is built with CUDA but run without GPUs.

### DIFF
--- a/include/El/core/imports/cuda.hpp
+++ b/include/El/core/imports/cuda.hpp
@@ -85,7 +85,12 @@ struct CudaError : std::runtime_error
   EL_FORCE_CHECK_CUDA_KERNEL(kernel, Dg, Db, Ns, S, args)
 #endif // #ifdef EL_RELEASE
 
-/** Initialize CUDA environment. */
+/** Initialize CUDA environment.
+ *  We assume that all MPI ranks within a compute node have access to
+ *  exactly one unique GPU or to the same (possibly empty) list of
+ *  GPUs. GPU assignments can be controled with the
+ *  CUDA_VISIBLE_DEVICES environment variable.
+ */
 void InitializeCUDA(int,char*[]);
 /** Finalize CUDA environment. */
 void FinalizeCUDA();


### PR DESCRIPTION
This also slightly cleans up the GPU assignment code. If a process sees only one GPU (e.g. if CUDA_VISIBLE_DEVICES is set), it just uses that GPU. If it sees multiple GPUs, it does a round-robin assignment (we assume in this case that all processes see the same exact list of GPUs).

Requesting a review from @mcneish1. How well does this match our environment on Ray/Sierra?