### PR TITLE
More careful management of CUB GPU memory pool.

### DIFF
--- a/include/El/core.hpp
+++ b/include/El/core.hpp
@@ -251,6 +251,9 @@ template<typename T> struct IsStdField<Complex<T>>
 #include <El/core/imports/cuda.hpp>
 #include <El/core/imports/cublas.hpp>
 #endif // HYDROGEN_HAVE_CUDA
+#ifdef HYDROGEN_HAVE_CUB
+#include <El/core/imports/cub.hpp>
+#endif // HYDROGEN_HAVE_CUB
 #include <El/core/imports/lapack.hpp>
 #include <El/core/imports/flame.hpp>
 #include <El/core/imports/mkl.hpp>

--- a/include/El/core/imports/CMakeLists.txt
+++ b/include/El/core/imports/CMakeLists.txt
@@ -1,6 +1,7 @@
 # Add the headers for this directory
 set_full_path(THIS_DIR_HEADERS
   blas.hpp
+  cub.hpp
   cuda.hpp
   cublas.hpp
   choice.hpp

--- a/include/El/core/imports/cub.hpp
+++ b/include/El/core/imports/cub.hpp
@@ -1,0 +1,19 @@
+#ifndef HYDROGEN_IMPORTS_CUB_HPP_
+#define HYDROGEN_IMPORTS_CUB_HPP_
+
+#include "cub/util_allocator.cuh"
+
+namespace El
+{
+namespace cub
+{
+
+    /** Get singleton instance of CUB memory pool. */
+    ::cub::CachingDeviceAllocator& MemoryPool();
+    /** Destroy singleton instance of CUB memory pool. */
+    void DestroyMemoryPool();
+
+} // namespace cub
+} // namespace El
+
+#endif // HYDROGEN_IMPORTS_CUB_HPP_

--- a/include/El/core/imports/cuda.hpp
+++ b/include/El/core/imports/cuda.hpp
@@ -85,7 +85,12 @@ struct CudaError : std::runtime_error
   EL_FORCE_CHECK_CUDA_KERNEL(kernel, Dg, Db, Ns, S, args)
 #endif // #ifdef EL_RELEASE
 
-/** Initialize CUDA environment. */
+/** Initialize CUDA environment.
+ *  We assume that all MPI ranks within a compute node have access to
+ *  exactly one unique GPU or to the same (possibly empty) list of
+ *  GPUs. GPU assignments can be controled with the
+ *  CUDA_VISIBLE_DEVICES environment variable.
+ */
 void InitializeCUDA(int,char*[]);
 /** Finalize CUDA environment. */
 void FinalizeCUDA();

--- a/src/core/imports/CMakeLists.txt
+++ b/src/core/imports/CMakeLists.txt
@@ -17,6 +17,10 @@ if (HYDROGEN_HAVE_CUDA)
   set_full_path(CUDA_SOURCES cuda.cpp cublas.cpp)
   list(APPEND THIS_DIR_SOURCES ${CUDA_SOURCES})
 endif()
+if (HYDROGEN_HAVE_CUB)
+  set_full_path(CUB_SOURCES cub.cpp)
+  list(APPEND THIS_DIR_SOURCES ${CUB_SOURCES})
+endif()
 
 # Add the subdirectories
 add_subdirectory(blas)

--- a/src/core/imports/cub.cpp
+++ b/src/core/imports/cub.cpp
@@ -1,0 +1,26 @@
+#include "El-lite.hpp"
+#include "El/core/imports/cub.hpp"
+
+namespace
+{
+/** Singleton instance of CUB memory pool. */
+std::unique_ptr<::cub::CachingDeviceAllocator> memoryPool_;
+} // namespace <anon>
+
+namespace El
+{
+namespace cub
+{
+
+::cub::CachingDeviceAllocator& MemoryPool()
+{
+    if (!memoryPool_)
+        memoryPool_.reset(new ::cub::CachingDeviceAllocator(2u));
+    return *memoryPool_;
+}
+
+void DestroyMemoryPool()
+{ memoryPool_.reset(); }
+
+} // namespace CUBMemoryPool
+} // namespace El

--- a/src/core/imports/cuda.cpp
+++ b/src/core/imports/cuda.cpp
@@ -1,5 +1,8 @@
 #include "El-lite.hpp"
 #include "El/core/imports/cuda.hpp"
+#ifdef HYDROGEN_HAVE_CUB
+#include "El/core/imports/cub.hpp"
+#endif // HYDROGEN_HAVE_CUB
 
 #include <cuda.h>
 #include <cuda_runtime.h>
@@ -80,6 +83,9 @@ void InitializeCUDA(int argc, char* argv[])
 
 void FinalizeCUDA()
 {
+#ifdef HYDROGEN_HAVE_CUB
+    cub::DestroyMemoryPool();
+#endif // HYDROGEN_HAVE_CUB
     GPUManager::Destroy();
 }
 


### PR DESCRIPTION
The memory pool is only instantiated when first needed and is destroyed during finalization. This is intended as a fix for https://github.com/LLNL/lbann/issues/380.