### PR TITLE
Initializes MPI before CUBLAS

### DIFF
--- a/include/El/core/imports/cublas.hpp
+++ b/include/El/core/imports/cublas.hpp
@@ -90,6 +90,10 @@ struct CublasError : std::runtime_error
 #define EL_CHECK_CUBLAS(cublas_call) EL_FORCE_CHECK_CUBLAS(cublas_call)
 #endif // #ifdef EL_RELEASE
 
+/** Initialize CUBLAS.
+ *  This must be called after MPI_Init is called with MVAPICH2-GDR.
+ */
+void InitializeCUBLAS();
 
 namespace cublas
 {

--- a/include/El/core/imports/cuda.hpp
+++ b/include/El/core/imports/cuda.hpp
@@ -110,6 +110,8 @@ public:
 
     /** Create new singleton instance of CUDA manager. */
     static void Create( int device = 0 );
+    /** Initilize CUBLAS. */
+    static void InitializeCUBLAS();
     /** Destroy singleton instance of CUDA manager. */
     static void Destroy();
     /** Get singleton instance of CUDA manager. */

--- a/src/core/environment.cpp
+++ b/src/core/environment.cpp
@@ -178,6 +178,10 @@ void Initialize( int& argc, char**& argv )
 #endif
     }
 
+#ifdef HYDROGEN_HAVE_CUDA
+    InitializeCUBLAS();
+#endif
+    
 #ifdef EL_HAVE_QT5
     InitializeQt5( argc, argv );
 #endif

--- a/src/core/imports/cublas.cpp
+++ b/src/core/imports/cublas.cpp
@@ -9,6 +9,10 @@
 namespace El
 {
 
+void InitializeCUBLAS()
+{
+    GPUManager::InitializeCUBLAS();
+}
 namespace cublas
 {
 

--- a/src/core/imports/cuda.cpp
+++ b/src/core/imports/cuda.cpp
@@ -105,13 +105,16 @@ GPUManager::GPUManager(int device)
     // Initialize CUDA and cuBLAS objects
     EL_FORCE_CHECK_CUDA(cudaSetDevice(device_));
     EL_FORCE_CHECK_CUDA(cudaStreamCreate(&stream_));
-    EL_FORCE_CHECK_CUBLAS(cublasCreate(&cublasHandle_));
-    EL_FORCE_CHECK_CUBLAS(cublasSetStream(cublasHandle_, stream_));
-    EL_FORCE_CHECK_CUBLAS(cublasSetPointerMode(cublasHandle_,
-                                               CUBLAS_POINTER_MODE_HOST));
 }
 
-
+void GPUManager::InitializeCUBLAS()
+{
+    EL_FORCE_CHECK_CUBLAS(cublasCreate(&Instance()->cublasHandle_));
+    EL_FORCE_CHECK_CUBLAS(cublasSetStream(cuBLASHandle(), Stream()));
+    EL_FORCE_CHECK_CUBLAS(cublasSetPointerMode(cuBLASHandle(),
+                                               CUBLAS_POINTER_MODE_HOST));
+}
+    
 GPUManager::~GPUManager()
 {
     try


### PR DESCRIPTION
This fixes a startup problem with MVAPICH-GDR. CUBALS initialization
allocates some device memory chunks, which MVAPICH-GDR attempts to
intercept but fails if MPI_Init is not called yet. So, the correct ordering
of initialization seems to be first CUDA, then MPI, and then any
libraries that depend on CUDA or MPI.