### PR TITLE
Use the internal CUB memory pool for everything by default

### DIFF
--- a/include/El/core.hpp
+++ b/include/El/core.hpp
@@ -267,7 +267,10 @@ template<typename T> struct IsStdField<Complex<T>>
 
 #include <El/core/Memory.hpp>
 
-namespace El {
+#include <El/core/SimpleBuffer.hpp>
+
+namespace El
+{
 
 template <typename T=double> class AbstractMatrix;
 template<typename T=double, Device D=Device::CPU> class Matrix;

--- a/include/El/core/Device.hpp
+++ b/include/El/core/Device.hpp
@@ -47,163 +47,12 @@ constexpr bool IsDeviceValidType_v() { return IsDeviceValidType<T,D>::value; }
 template <Device D1, Device D2>
 using SameDevice = EnumSame<Device,D1,D2>;
 
-// A simple data management class for temporary contiguous memory blocks
-template <typename T, Device D> class simple_buffer;
+// Basic inter-device memory operations
+template <Device SrcD, Device DestD> struct InterDeviceCopy;
 
-template <typename T>
-class simple_buffer<T,Device::CPU>
-{
-public:
-    simple_buffer() = default;
 
-    simple_buffer(size_t size)
-    {
-        this->allocate(size);
-    }
-
-    simple_buffer(size_t size, T const& value)
-        : vec_(size, value)
-    {
-        data_ = vec_.data();
-    }
-
-    void allocate(size_t size)
-    {
-        vec_.reserve(size);
-        size_ = size;
-        data_ = vec_.data();
-    }
-
-    size_t size() const noexcept
-    {
-        return size_;
-    }
-
-    T* data() noexcept { return data_; }
-    T const* data() const noexcept { return data_; }
 
 #ifdef HYDROGEN_HAVE_CUDA
-    void shallowCopyIfPossible(simple_buffer<T,Device::GPU>& A)
-    {
-        // Shallow copy not possible
-        this->allocate(A.size());
-        auto stream = GPUManager::Stream();
-        EL_CHECK_CUDA(cudaMemcpyAsync(data_, A.data(), size_*sizeof(T),
-                                      cudaMemcpyDeviceToHost,
-                                      stream));
-        EL_CHECK_CUDA(cudaStreamSynchronize(stream));
-    }
-#endif // HYDROGEN_HAVE_CUDA
-
-    void shallowCopyIfPossible(simple_buffer<T,Device::CPU>& A)
-    {
-        data_ = A.data();
-        size_ = A.size();
-    }
-
-private:
-    T* data_ = nullptr;// To be used as VIEW ONLY.
-    std::vector<T> vec_;
-    size_t size_ = 0;
-};// class simple_buffer<T,Device::CPU>
-
-#ifdef HYDROGEN_HAVE_CUDA
-template <typename T>
-class simple_buffer<T,Device::GPU>
-{
-public:
-    simple_buffer() = default;
-
-    simple_buffer(size_t size)
-    {
-        this->allocate(size);
-    }
-
-    simple_buffer(size_t size, T const& value)
-        : simple_buffer(size)
-    {
-        if( value == T(0) )
-        {
-            EL_CHECK_CUDA(cudaMemsetAsync(data_, 0x0, size*sizeof(T),
-                                          GPUManager::Stream()));
-        }
-        else
-        {
-            simple_buffer<T,Device::CPU> cpuBuffer(size, value);
-            shallowCopyIfPossible(cpuBuffer);
-        }
-    }
-
-    ~simple_buffer()
-    {
-        if (data_ && own_data_)
-        {
-            try
-            {
-                EL_CHECK_CUDA(cudaFree(data_));
-            }
-            catch (std::exception const& e)
-            {
-                std::cerr << "cudaFree error detected:\n\n"
-                          << e.what() << std::endl
-                          << "std::terminate() will be called."
-                          << std::endl;
-                std::terminate();
-            }
-            data_ = nullptr;
-        }
-    }
-
-    void allocate(size_t size)
-    {
-        if (size < size_ && own_data_)
-        {
-            size_ = size;
-            return;
-        }
-
-        T* ptr;
-        EL_CHECK_CUDA(cudaMalloc(&ptr, size*sizeof(T)));
-        std::swap(data_,ptr);
-        const bool own_ptr = own_data_;
-        own_data_ = true;
-        size_ = size;
-        if (ptr && own_ptr)
-        {
-            EL_CHECK_CUDA(cudaFree(ptr));
-            ptr = nullptr;
-        }
-    }
-
-    T* data() noexcept { return data_; }
-    T const* data() const noexcept { return data_; }
-
-    size_t size() const noexcept { return size_; }
-
-    void shallowCopyIfPossible(simple_buffer<T,Device::CPU>& A)
-    {
-        // Shallow copy not possible
-        this->allocate(A.size());
-        auto stream = GPUManager::Stream();
-        EL_CHECK_CUDA(cudaMemcpyAsync(data_, A.data(), size_*sizeof(T),
-                                      cudaMemcpyHostToDevice,
-                                      stream));
-        EL_CHECK_CUDA(cudaStreamSynchronize(stream));
-    }
-
-    void shallowCopyIfPossible(simple_buffer<T,Device::GPU>& A)
-    {
-        if (own_data_)
-            LogicError("Can't shallowCopy into buffer that owns data.");
-        data_ = A.data();
-        size_ = A.size();
-    }
-private:
-    T* data_ = nullptr;
-    size_t size_ = 0;
-    bool own_data_ = false;
-};// class simple_buffer<T,Device::GPU>
-
 
 template <Device D1, Device D2>
 constexpr cudaMemcpyKind CUDAMemcpyKind();
@@ -226,6 +75,69 @@ constexpr cudaMemcpyKind CUDAMemcpyKind<Device::GPU,Device::GPU>()
     return cudaMemcpyDeviceToDevice;
 }
 
+template <>
+struct InterDeviceCopy<Device::CPU,Device::GPU>
+{
+    template <typename T>
+    static void MemCopy1D(T * EL_RESTRICT const dest,
+                          T const* EL_RESTRICT const src,
+                          Int const size)
+    {
+        auto stream = GPUManager::Stream();
+        EL_CHECK_CUDA(cudaMemcpyAsync(
+                          dest, src, size*sizeof(T),
+                          CUDAMemcpyKind<Device::CPU,Device::GPU>(),
+                          stream));
+        EL_CHECK_CUDA(cudaStreamSynchronize(stream));
+    }
+
+
+    template <typename T>
+    static void MemCopy2D(T * EL_RESTRICT const dest, Int const dest_ldim,
+                   T const* EL_RESTRICT const src, Int const src_ldim,
+                   Int const height, Int const width)
+    {
+        auto stream = GPUManager::Stream();
+        EL_CHECK_CUDA(cudaMemcpy2DAsync(
+            dest, dest_ldim*sizeof(T),
+            src, src_ldim*sizeof(T),
+            height*sizeof(T), width,
+            CUDAMemcpyKind<Device::CPU,Device::GPU>(),
+            stream));
+        EL_CHECK_CUDA(cudaStreamSynchronize(stream));
+    }
+};// InterDevice<CPU,GPU>
+
+template <>
+struct InterDeviceCopy<Device::GPU,Device::CPU>
+{
+    template <typename T>
+    static void MemCopy1D(T * EL_RESTRICT const dest,
+                          T const* EL_RESTRICT const src, Int const size)
+    {
+        auto stream = GPUManager::Stream();
+        EL_CHECK_CUDA(cudaMemcpyAsync(
+                          dest, src, size*sizeof(T),
+                          CUDAMemcpyKind<Device::GPU,Device::CPU>(),
+                          stream));
+        EL_CHECK_CUDA(cudaStreamSynchronize(stream));
+    }
+
+    template <typename T>
+    static void MemCopy2D(T * EL_RESTRICT const dest, Int const dest_ldim,
+                   T const* EL_RESTRICT const src, Int const src_ldim,
+                   Int const height, Int const width)
+    {
+        auto stream = GPUManager::Stream();
+        EL_CHECK_CUDA(cudaMemcpy2DAsync(
+            dest, dest_ldim*sizeof(T),
+            src, src_ldim*sizeof(T),
+            height*sizeof(T), width,
+            CUDAMemcpyKind<Device::GPU,Device::CPU>(),
+            stream));
+        EL_CHECK_CUDA(cudaStreamSynchronize(stream));
+    }
+};// InterDevice<CPU,GPU>
 #endif // HYDROGEN_HAVE_CUDA
 
 }// namespace El

--- a/include/El/core/Memory/decl.hpp
+++ b/include/El/core/Memory/decl.hpp
@@ -39,6 +39,7 @@ class Memory
 {
 public:
     Memory();
+    Memory(size_t size);
     Memory(size_t size, unsigned int mode);
     ~Memory();
 

--- a/include/El/core/Memory/decl.hpp
+++ b/include/El/core/Memory/decl.hpp
@@ -12,12 +12,34 @@
 namespace El
 {
 
+template <Device D>
+constexpr unsigned DefaultMemoryMode();
+
+template <>
+constexpr unsigned DefaultMemoryMode<Device::CPU>()
+{
+    return 0;
+}
+
+#ifdef HYDROGEN_HAVE_CUDA
+template <>
+constexpr unsigned DefaultMemoryMode<Device::GPU>()
+{
+#ifdef HYDROGEN_HAVE_CUB
+    return 1;
+#else
+    return 0;
+#endif
+}
+#endif // HYDROGEN_HAVE_CUB
+
+
 template<typename G, Device D=Device::CPU>
 class Memory
 {
 public:
     Memory();
-    Memory(size_t size, unsigned int mode = 0);
+    Memory(size_t size, unsigned int mode);
     ~Memory();
 
     Memory(Memory<G,D>&& mem);
@@ -39,7 +61,7 @@ private:
     size_t size_;
     G* rawBuffer_;
     G* buffer_;
-    unsigned int mode_;
+    unsigned int mode_ = DefaultMemoryMode<D>();
 };// class Memory
 
 } // namespace El

--- a/include/El/core/SimpleBuffer.hpp
+++ b/include/El/core/SimpleBuffer.hpp
@@ -10,8 +10,10 @@ class simple_buffer
 {
 public:
     simple_buffer() = default;
-    explicit simple_buffer(size_t size, unsigned int mode = 0);
-    explicit simple_buffer(size_t size, T const& value, unsigned int mode = 0);
+    explicit simple_buffer(size_t size,
+                           unsigned int mode = DefaultMemoryMode<D>());
+    explicit simple_buffer(size_t size, T const& value,
+                           unsigned int mode = DefaultMemoryMode<D>());
 
     void allocate(size_t size);
 

--- a/include/El/core/SimpleBuffer.hpp
+++ b/include/El/core/SimpleBuffer.hpp
@@ -1,0 +1,123 @@
+#ifndef EL_CORE_SIMPLEBUFFER_HPP_
+#define EL_CORE_SIMPLEBUFFER_HPP_
+
+namespace El
+{
+
+// A simple data management class for temporary contiguous memory blocks
+template <typename T, Device D>
+class simple_buffer
+{
+public:
+    simple_buffer() = default;
+    explicit simple_buffer(size_t size, unsigned int mode = 0);
+    explicit simple_buffer(size_t size, T const& value, unsigned int mode = 0);
+
+    void allocate(size_t size);
+
+    void shallowCopyIfPossible(simple_buffer<T,D>& other)
+    {
+        data_ = other.data();
+        size_ = other.size();
+    }
+
+    template <Device D2>
+    void shallowCopyIfPossible(simple_buffer<T,D2>& other)
+    {
+        data_ = mem_.Require(other.size());
+        size_ = other.size();
+
+        InterDeviceCopy<D2,D>::MemCopy1D(data_, other.data(), size_);
+    }
+
+    size_t size() const noexcept;
+    T* data() noexcept;
+    T const* data() const noexcept;
+
+private:
+    Memory<T,D> mem_;
+    T* data_;
+    size_t size_;
+}; // class simple_buffer
+
+
+namespace details
+{
+template <Device D> struct MemorySetter;
+
+template <>
+struct MemorySetter<Device::CPU>
+{
+    template <typename T>
+    static void setBufferToValue(T* buffer, size_t size, T const& value)
+    {
+        std::fill_n(buffer, size, value);
+    }
+};// struct MemorySetter<Device::CPU>
+
+#ifdef HYDROGEN_HAVE_CUDA
+template <>
+struct MemorySetter<Device::GPU>
+{
+    template<typename T>
+    static void setBufferToValue(T* buffer, size_t size, T const& value)
+    {
+        if( value == T(0) )
+        {
+            EL_CHECK_CUDA(cudaMemsetAsync(buffer, 0x0, size*sizeof(T),
+                                          GPUManager::Stream()));
+        }
+        else
+        {
+            std::vector<T> tmp(size, value);
+            EL_CHECK_CUDA(cudaMemcpyAsync(
+                              buffer, tmp.data(), size*sizeof(T),
+                              CUDAMemcpyKind<Device::CPU,Device::GPU>(),
+                              GPUManager::Stream()));
+        }
+    }
+};// struct MemorySetter<Device::GPU>
+#endif // HYDROGEN_HAVE_CUDA
+}// namespace details
+
+
+template <typename T, Device D>
+simple_buffer<T,D>::simple_buffer(size_t size, unsigned int mode)
+    : mem_{size, mode},
+      data_{mem_.Buffer()},
+      size_{mem_.Size()}
+{}
+
+template <typename T, Device D>
+simple_buffer<T,D>::simple_buffer(size_t size, T const& value, unsigned mode)
+    : simple_buffer{size, mode}
+{
+    details::MemorySetter<D>::setBufferToValue(this->data(), size, value);
+}
+
+template <typename T, Device D>
+void simple_buffer<T,D>::allocate(size_t size)
+{
+    data_ = mem_.Require(size);
+    size_ = size;
+}
+
+template <typename T, Device D>
+size_t simple_buffer<T,D>::size() const noexcept
+{
+    return size_;
+}
+
+template <typename T, Device D>
+T* simple_buffer<T,D>::data() noexcept
+{
+    return data_;
+}
+
+template <typename T, Device D>
+T const* simple_buffer<T,D>::data() const noexcept
+{
+    return data_;
+}
+}// namespace El
+#endif // EL_CORE_SIMPLEBUFFER_HPP_


### PR DESCRIPTION
Unless you specify the mode, it will use "new" on CPUs and CUB on GPUs by default.