### PR TITLE
Stop some abuse of global variables

### DIFF
--- a/include/El/core/imports/mpi.hpp
+++ b/include/El/core/imports/mpi.hpp
@@ -36,9 +36,8 @@ namespace mpi {
 
 struct Comm
 {
-    static unsigned long count;
     MPI_Comm comm;
-    Comm( MPI_Comm mpiComm=MPI_COMM_WORLD ) EL_NO_EXCEPT : comm(mpiComm) {printf("COMM %lu\n", count++); }
+    Comm( MPI_Comm mpiComm=MPI_COMM_WORLD ) EL_NO_EXCEPT : comm(mpiComm) { }
 
     inline int Rank() const EL_NO_RELEASE_EXCEPT;
     inline int Size() const EL_NO_RELEASE_EXCEPT;

--- a/include/El/core/imports/mpi.hpp
+++ b/include/El/core/imports/mpi.hpp
@@ -36,8 +36,9 @@ namespace mpi {
 
 struct Comm
 {
+    static unsigned long count;
     MPI_Comm comm;
-    Comm( MPI_Comm mpiComm=MPI_COMM_WORLD ) EL_NO_EXCEPT : comm(mpiComm) { }
+    Comm( MPI_Comm mpiComm=MPI_COMM_WORLD ) EL_NO_EXCEPT : comm(mpiComm) {printf("COMM %lu\n", count++); }
 
     inline int Rank() const EL_NO_RELEASE_EXCEPT;
     inline int Size() const EL_NO_RELEASE_EXCEPT;
@@ -98,39 +99,39 @@ struct Request
 };
 
 // Standard constants
-const int ANY_SOURCE = MPI_ANY_SOURCE;
-const int ANY_TAG = MPI_ANY_TAG;
+extern const int ANY_SOURCE;
+extern const int ANY_TAG;
 #ifdef EL_HAVE_MPI_QUERY_THREAD
-const int THREAD_SINGLE = MPI_THREAD_SINGLE;
-const int THREAD_FUNNELED = MPI_THREAD_FUNNELED;
-const int THREAD_SERIALIZED = MPI_THREAD_SERIALIZED;
-const int THREAD_MULTIPLE = MPI_THREAD_MULTIPLE;
+extern const int THREAD_SINGLE;
+extern const int THREAD_FUNNELED;
+extern const int THREAD_SERIALIZED;
+extern const int THREAD_MULTIPLE;
 #else
-const int THREAD_SINGLE = 0;
-const int THREAD_FUNNELED = 1;
-const int THREAD_SERIALIZED = 2;
-const int THREAD_MULTIPLE = 3;
+extern const int THREAD_SINGLE;
+extern const int THREAD_FUNNELED;
+extern const int THREAD_SERIALIZED;
+extern const int THREAD_MULTIPLE;
 #endif
-const int UNDEFINED = MPI_UNDEFINED;
-const Group GROUP_NULL = MPI_GROUP_NULL;
-const Comm COMM_NULL = MPI_COMM_NULL;
-const Comm COMM_SELF = MPI_COMM_SELF;
-const Comm COMM_WORLD = MPI_COMM_WORLD;
-const ErrorHandler ERRORS_RETURN = MPI_ERRORS_RETURN;
-const ErrorHandler ERRORS_ARE_FATAL = MPI_ERRORS_ARE_FATAL;
-const Group GROUP_EMPTY = MPI_GROUP_EMPTY;
-const Op MAX = MPI_MAX;
-const Op MIN = MPI_MIN;
-const Op MAXLOC = MPI_MAXLOC;
-const Op MINLOC = MPI_MINLOC;
-const Op PROD = MPI_PROD;
-const Op SUM = MPI_SUM;
-const Op LOGICAL_AND = MPI_LAND;
-const Op LOGICAL_OR = MPI_LOR;
-const Op LOGICAL_XOR = MPI_LXOR;
-const Op BINARY_AND = MPI_BAND;
-const Op BINARY_OR = MPI_BOR;
-const Op BINARY_XOR = MPI_BXOR;
+extern const int UNDEFINED;
+extern const Group GROUP_NULL;
+extern const Comm COMM_NULL;// = MPI_COMM_NULL;
+extern const Comm COMM_SELF;// = MPI_COMM_SELF;
+extern const Comm COMM_WORLD;// = MPI_COMM_WORLD;
+extern const ErrorHandler ERRORS_RETURN;
+extern const ErrorHandler ERRORS_ARE_FATAL;
+extern const Group GROUP_EMPTY;
+extern const Op MAX;
+extern const Op MIN;
+extern const Op MAXLOC;
+extern const Op MINLOC;
+extern const Op PROD;
+extern const Op SUM;
+extern const Op LOGICAL_AND;
+extern const Op LOGICAL_OR;
+extern const Op LOGICAL_XOR;
+extern const Op BINARY_AND;
+extern const Op BINARY_OR;
+extern const Op BINARY_XOR;
 
 template<typename T>
 struct Types

--- a/src/core/imports/mpi.cpp
+++ b/src/core/imports/mpi.cpp
@@ -69,6 +69,41 @@ MPI_Op NativeOp( const El::mpi::Op& op )
 namespace El {
 namespace mpi {
 
+unsigned long Comm::count = 0UL;
+const int ANY_SOURCE = MPI_ANY_SOURCE;
+const int ANY_TAG = MPI_ANY_TAG;
+#ifdef EL_HAVE_MPI_QUERY_THREAD
+const int THREAD_SINGLE = MPI_THREAD_SINGLE;
+const int THREAD_FUNNELED = MPI_THREAD_FUNNELED;
+const int THREAD_SERIALIZED = MPI_THREAD_SERIALIZED;
+const int THREAD_MULTIPLE = MPI_THREAD_MULTIPLE;
+#else
+const int THREAD_SINGLE = 0;
+const int THREAD_FUNNELED = 1;
+const int THREAD_SERIALIZED = 2;
+const int THREAD_MULTIPLE = 3;
+#endif
+const int UNDEFINED = MPI_UNDEFINED;
+const Group GROUP_NULL = MPI_GROUP_NULL;
+const Comm COMM_NULL = MPI_COMM_NULL;
+const Comm COMM_SELF = MPI_COMM_SELF;
+const Comm COMM_WORLD = MPI_COMM_WORLD;
+const ErrorHandler ERRORS_RETURN = MPI_ERRORS_RETURN;
+const ErrorHandler ERRORS_ARE_FATAL = MPI_ERRORS_ARE_FATAL;
+const Group GROUP_EMPTY = MPI_GROUP_EMPTY;
+const Op MAX = MPI_MAX;
+const Op MIN = MPI_MIN;
+const Op MAXLOC = MPI_MAXLOC;
+const Op MINLOC = MPI_MINLOC;
+const Op PROD = MPI_PROD;
+const Op SUM = MPI_SUM;
+const Op LOGICAL_AND = MPI_LAND;
+const Op LOGICAL_OR = MPI_LOR;
+const Op LOGICAL_XOR = MPI_LXOR;
+const Op BINARY_AND = MPI_BAND;
+const Op BINARY_OR = MPI_BOR;
+const Op BINARY_XOR = MPI_BXOR;
+
 bool CommSameSizeAsInteger() EL_NO_EXCEPT
 { return sizeof(MPI_Comm) == sizeof(int); }
 

--- a/src/core/imports/mpi.cpp
+++ b/src/core/imports/mpi.cpp
@@ -69,7 +69,6 @@ MPI_Op NativeOp( const El::mpi::Op& op )
 namespace El {
 namespace mpi {
 
-unsigned long Comm::count = 0UL;
 const int ANY_SOURCE = MPI_ANY_SOURCE;
 const int ANY_TAG = MPI_ANY_TAG;
 #ifdef EL_HAVE_MPI_QUERY_THREAD


### PR DESCRIPTION
Each compilation unit was contributing its COMM_WORLD, etc, so each process was spawning about 400 mpi::Comm objects (fortunately this is just pointer copies). Now there's a unique COMM_WORLD, COMM_SELF, etc. It's possible some of the "int"s were fine, but this makes the whole thing uniform.