### PR TITLE
Fix a bug in which an AbstractMatrix could have a size but no memory

### DIFF
--- a/include/El/core/AbstractMatrix.hpp
+++ b/include/El/core/AbstractMatrix.hpp
@@ -272,8 +272,8 @@ inline void AbstractMatrix<T>::Resize_(
         || leadingDimension != this->LDim())
     {
         this->SetSize_(height, width, leadingDimension);
-        do_resize_();
     }
+    do_resize_();
 }
 
 template <typename T>


### PR DESCRIPTION
There was a bug. I think this is ok now. If there's enough memory already, nothing should happen.