### PR TITLE
Work around LAPACK dependency if LAPACK not found

### DIFF
--- a/cmake/configure_files/hydrogen_config.h.in
+++ b/cmake/configure_files/hydrogen_config.h.in
@@ -17,6 +17,8 @@
 #cmakedefine HYDROGEN_HAVE_QD
 #cmakedefine HYDROGEN_HAVE_MPC
 
+#cmakedefine HYDROGEN_HAVE_LAPACK
+
 #cmakedefine HYDROGEN_HAVE_MKL
 #cmakedefine HYDROGEN_HAVE_MKL_GEMMT
 

--- a/cmake/modules/FindAndVerifyLAPACK.cmake
+++ b/cmake/modules/FindAndVerifyLAPACK.cmake
@@ -141,8 +141,8 @@ check_function_exists(dgemm BLAS_NO_USE_UNDERSCORE)
 check_function_exists(dgemm_ BLAS_USE_UNDERSCORE)
 
 set(CMAKE_REQUIRED_LIBRARIES "${LAPACK_LINKER_FLAGS}" "${LAPACK_LIBRARIES}")
-check_function_exists(dgetrs LAPACK_NO_USE_UNDERSCORE)
-check_function_exists(dgetrs_ LAPACK_USE_UNDERSCORE)
+check_function_exists(dlacpy LAPACK_NO_USE_UNDERSCORE)
+check_function_exists(dlacpy_ LAPACK_NO_USE_UNDERSCORE)
 
 # If both dgemm and dgemm_ are found, don't use the suffix
 if (BLAS_NO_USE_UNDERSCORE)
@@ -155,6 +155,7 @@ else ()
   message(FATAL_ERROR "Could not determine BLAS suffix!")
 endif ()
 
+set(${UPPER_PROJECT_NAME}_HAVE_LAPACK ON)
 if (LAPACK_NO_USE_UNDERSCORE)
   unset(${UPPER_PROJECT_NAME}_LAPACK_SUFFIX)
   message(STATUS "Using LAPACK with no symbol mangling.")
@@ -162,7 +163,9 @@ elseif (LAPACK_USE_UNDERSCORE)
   set(${UPPER_PROJECT_NAME}_LAPACK_SUFFIX "_")
   message(STATUS "Using LAPACK with trailing underscore.")
 else ()
-  message(FATAL_ERROR "Could not determine LAPACK suffix!")
+  message(STATUS
+    "Could not find LAPACK's copy function. Disabling LAPACK support.")
+  set(${UPPER_PROJECT_NAME}_HAVE_LAPACK)
 endif ()
 
 # Check a few MKL features
@@ -171,3 +174,4 @@ if (${UPPER_PROJECT_NAME}_HAVE_MKL)
   check_function_exists(dgemmt  ${UPPER_PROJECT_NAME}_HAVE_MKL_GEMMT)
   check_function_exists(dgemmt_ ${UPPER_PROJECT_NAME}_HAVE_MKL_GEMMT)
 endif ()
+set(CMAKE_REQUIRED_LIBRARIES)

--- a/include/El/blas_like/level1/Copy/util.hpp
+++ b/include/El/blas_like/level1/Copy/util.hpp
@@ -307,6 +307,7 @@ struct Impl<T, Device::GPU, true>
             const Int localHeight = Length_(height, colShift, colStride);
 
             (void)colOffset;
+            (void)localHeight;
             LogicError("PartialColStridedColumnPack<T,GPU>: Not implemented.");
 #if 0
             StridedMemCopy

--- a/include/El/core/imports/lapack.hpp
+++ b/include/El/core/imports/lapack.hpp
@@ -2,8 +2,8 @@
    Copyright (c) 2009-2016, Jack Poulson
    All rights reserved.
 
-   This file is part of Elemental and is under the BSD 2-Clause License, 
-   which can be found in the LICENSE file in the root directory, or at 
+   This file is part of Elemental and is under the BSD 2-Clause License,
+   which can be found in the LICENSE file in the root directory, or at
    http://opensource.org/licenses/BSD-2-Clause
 */
 #ifndef EL_IMPORTS_LAPACK_HPP
@@ -17,29 +17,30 @@ namespace lapack {
 // =================================
 template<typename T>
 void Copy
-( char uplo, BlasInt m, BlasInt n, 
+( char uplo, BlasInt m, BlasInt n,
   const T* A, BlasInt lda, T* B, BlasInt ldb );
 
+#ifdef HYDROGEN_USE_LAPACK
 void Copy
-( char uplo, BlasInt m, BlasInt n, 
+( char uplo, BlasInt m, BlasInt n,
   const float* A, BlasInt lda, float* B, BlasInt ldb );
 void Copy
-( char uplo, BlasInt m, BlasInt n, 
+( char uplo, BlasInt m, BlasInt n,
   const double* A, BlasInt lda, double* B, BlasInt ldb );
 void Copy
-( char uplo, BlasInt m, BlasInt n, 
+( char uplo, BlasInt m, BlasInt n,
   const scomplex* A, BlasInt lda, scomplex* B, BlasInt ldb );
 void Copy
-( char uplo, BlasInt m, BlasInt n, 
+( char uplo, BlasInt m, BlasInt n,
   const dcomplex* A, BlasInt lda, dcomplex* B, BlasInt ldb );
 template<typename T>
 void Copy
-( char uplo, BlasInt m, BlasInt n, 
+( char uplo, BlasInt m, BlasInt n,
   const T* A, BlasInt lda, T* B, BlasInt ldb );
 
 // Generate a Householder reflector
 // ================================
-// NOTE: 
+// NOTE:
 // Since LAPACK chooses to use the identity matrix, rather than a single
 // coordinate negation, in cases where the mass is already entirely in the
 // first entry, and the identity matrix cannot be represented as a Householder
@@ -69,13 +70,13 @@ F Reflector( BlasInt n, F& chi, F* x, BlasInt incx );
 template<typename F>
 void ApplyReflector
 ( bool onLeft, BlasInt m, BlasInt n,
-  const F* v, BlasInt vInc, 
+  const F* v, BlasInt vInc,
   const F& tau,
         F* C, BlasInt CLDim );
 template<typename F>
 void ApplyReflector
 ( bool onLeft, BlasInt m, BlasInt n,
-  const F* v, BlasInt vInc, 
+  const F* v, BlasInt vInc,
   const F& tau,
         F* C, BlasInt CLDim,
         F* work );
@@ -96,10 +97,10 @@ void SymmetricTridiagEig
 // Floating-point range
 // ^^^^^^^^^^^^^^^^^^^^
 BlasInt SymmetricTridiagEig
-( BlasInt n, float* d, float* e, float* w, 
+( BlasInt n, float* d, float* e, float* w,
   float vl, float vu, float abstol=0 );
 BlasInt SymmetricTridiagEig
-( BlasInt n, double* d, double* e, double* w, 
+( BlasInt n, double* d, double* e, double* w,
   double vl, double vu, double abstol=0 );
 
 // Index range
@@ -117,10 +118,10 @@ void SymmetricTridiagEig
 // All eigenpairs
 // ^^^^^^^^^^^^^^
 void SymmetricTridiagEig
-( BlasInt n, 
+( BlasInt n,
   float* d, float* e, float* w, float* Z, BlasInt ldZ, float abstol=0 );
 void SymmetricTridiagEig
-( BlasInt n, 
+( BlasInt n,
   double* d, double* e, double* w, double* Z, BlasInt ldZ, double abstol=0 );
 
 // Floating-point range
@@ -194,25 +195,25 @@ void HermitianEig
 // All eigenpairs
 // ^^^^^^^^^^^^^^
 void HermitianEig
-( char uplo, BlasInt n, 
+( char uplo, BlasInt n,
   float* A, BlasInt ldA,
   float* w,
   float* Z, BlasInt ldZ,
   float abstol=0 );
 void HermitianEig
-( char uplo, BlasInt n, 
+( char uplo, BlasInt n,
   double* A, BlasInt ldA,
   double* w,
   double* Z, BlasInt ldZ,
   double abstol=0 );
 void HermitianEig
-( char uplo, BlasInt n, 
+( char uplo, BlasInt n,
   scomplex* A, BlasInt ldA,
   float* w,
   scomplex* Z, BlasInt ldZ,
   float abstol=0 );
 void HermitianEig
-( char uplo, BlasInt n, 
+( char uplo, BlasInt n,
   dcomplex* A, BlasInt ldA,
   double* w,
   dcomplex* Z, BlasInt ldZ,
@@ -221,28 +222,28 @@ void HermitianEig
 // Floating-point range
 // ^^^^^^^^^^^^^^^^^^^^
 BlasInt HermitianEig
-( char uplo, BlasInt n, 
+( char uplo, BlasInt n,
   float* A, BlasInt ldA,
   float* w,
   float* Z, BlasInt ldZ,
   float vl, float vu,
   float abstol=0 );
 BlasInt HermitianEig
-( char uplo, BlasInt n, 
+( char uplo, BlasInt n,
   double* A, BlasInt ldA,
   double* w,
   double* Z, BlasInt ldZ,
   double vl, double vu,
   double abstol=0 );
 BlasInt HermitianEig
-( char uplo, BlasInt n, 
+( char uplo, BlasInt n,
   scomplex* A, BlasInt ldA,
   float* w,
   scomplex* Z, BlasInt ldZ,
   float vl, float vu,
   float abstol=0 );
 BlasInt HermitianEig
-( char uplo, BlasInt n, 
+( char uplo, BlasInt n,
   dcomplex* A, BlasInt ldA,
   double* w,
   dcomplex* Z, BlasInt ldZ,
@@ -252,28 +253,28 @@ BlasInt HermitianEig
 // Index range
 // ^^^^^^^^^^^
 void HermitianEig
-( char uplo, BlasInt n, 
+( char uplo, BlasInt n,
   float* A, BlasInt ldA,
   float* w,
   float* Z, BlasInt ldZ,
   BlasInt il, BlasInt iu,
   float abstol=0 );
 void HermitianEig
-( char uplo, BlasInt n, 
+( char uplo, BlasInt n,
   double* A, BlasInt ldA,
   double* w,
   double* Z, BlasInt ldZ,
   BlasInt il, BlasInt iu,
   double abstol=0 );
 void HermitianEig
-( char uplo, BlasInt n, 
+( char uplo, BlasInt n,
   scomplex* A, BlasInt ldA,
   float* w,
   scomplex* Z, BlasInt ldZ,
   BlasInt il, BlasInt iu,
   float abstol=0 );
 void HermitianEig
-( char uplo, BlasInt n, 
+( char uplo, BlasInt n,
   dcomplex* A, BlasInt ldA,
   double* w,
   dcomplex* Z, BlasInt ldZ,
@@ -285,28 +286,28 @@ void HermitianEig
 
 void DivideAndConquerSVD
 ( BlasInt m, BlasInt n,
-  float* A, BlasInt ldA, 
+  float* A, BlasInt ldA,
   float* s,
   float* U, BlasInt ldU,
   float* VT, BlasInt ldVT,
   bool thin=true );
 void DivideAndConquerSVD
 ( BlasInt m, BlasInt n,
-  double* A, BlasInt ldA, 
+  double* A, BlasInt ldA,
   double* s,
   double* U, BlasInt ldU,
   double* VT, BlasInt ldVT,
   bool thin=true );
 void DivideAndConquerSVD
 ( BlasInt m, BlasInt n,
-  scomplex* A, BlasInt ldA, 
+  scomplex* A, BlasInt ldA,
   float* s,
   scomplex* U, BlasInt ldU,
   scomplex* VH, BlasInt ldVH,
   bool thin=true );
 void DivideAndConquerSVD
 ( BlasInt m, BlasInt n,
-  dcomplex* A, BlasInt ldA, 
+  dcomplex* A, BlasInt ldA,
   double* s,
   dcomplex* U, BlasInt ldU,
   dcomplex* VH, BlasInt ldVH,
@@ -317,28 +318,28 @@ void DivideAndConquerSVD
 
 void QRSVD
 ( BlasInt m, BlasInt n,
-  float* A, BlasInt ldA, 
+  float* A, BlasInt ldA,
   float* s,
   float* U, BlasInt ldU,
   float* VT, BlasInt ldVT,
   bool thin=true, bool avoidU=false, bool avoidV=false );
 void QRSVD
 ( BlasInt m, BlasInt n,
-  double* A, BlasInt ldA, 
+  double* A, BlasInt ldA,
   double* s,
   double* U, BlasInt ldU,
   double* VT, BlasInt ldVT,
   bool thin=true, bool avoidU=false, bool avoidV=false );
 void QRSVD
 ( BlasInt m, BlasInt n,
-  scomplex* A, BlasInt ldA, 
+  scomplex* A, BlasInt ldA,
   float* s,
   scomplex* U, BlasInt ldU,
   scomplex* VH, BlasInt ldVH,
   bool thin=true, bool avoidU=false, bool avoidV=false );
 void QRSVD
 ( BlasInt m, BlasInt n,
-  dcomplex* A, BlasInt ldA, 
+  dcomplex* A, BlasInt ldA,
   double* s,
   dcomplex* U, BlasInt ldU,
   dcomplex* VH, BlasInt ldVH,
@@ -365,13 +366,13 @@ void BidiagSVDQRAlg
 ( char uplo, BlasInt n, BlasInt numColsVT, BlasInt numRowsU,
   float* d, float* e, float* VT, BlasInt ldVT, float* U, BlasInt ldU );
 void BidiagSVDQRAlg
-( char uplo, BlasInt n, BlasInt numColsVT, BlasInt numRowsU, 
+( char uplo, BlasInt n, BlasInt numColsVT, BlasInt numRowsU,
   double* d, double* e, double* VT, BlasInt ldVT, double* U, BlasInt ldU );
 void BidiagSVDQRAlg
 ( char uplo, BlasInt n, BlasInt numColsVH, BlasInt numRowsU,
   float* d, float* e, scomplex* VH, BlasInt ldVH, scomplex* U, BlasInt ldU );
 void BidiagSVDQRAlg
-( char uplo, BlasInt n, BlasInt numColsVH, BlasInt numRowsU, 
+( char uplo, BlasInt n, BlasInt numColsVH, BlasInt numRowsU,
   double* d, double* e, dcomplex* VH, BlasInt ldVH, dcomplex* U, BlasInt ldU );
 
 // Reduce a general square matrix to upper Hessenberg form
@@ -438,7 +439,7 @@ bool Solve4x4FullPiv
 
 // Small Sylvester
 // ===============
-// Solve a 1x1, 1x2, 2x1, or 2x2 real Sylvester equation, 
+// Solve a 1x1, 1x2, 2x1, or 2x2 real Sylvester equation,
 //
 //   op_C(C) X +- X op_D(D) = scale*B,
 //
@@ -471,7 +472,7 @@ bool SmallSylvester
 template<typename Real>
 void AdjacentSchurExchange
 ( BlasInt n,
-  Real* T, BlasInt TLDim, 
+  Real* T, BlasInt TLDim,
   BlasInt j1,
   BlasInt n1,
   BlasInt n2,
@@ -480,7 +481,7 @@ void AdjacentSchurExchange
 template<typename Real>
 void AdjacentSchurExchange
 ( BlasInt n,
-  Real* T, BlasInt TLDim, 
+  Real* T, BlasInt TLDim,
   Real* Q, BlasInt QLDim,
   BlasInt j1,
   BlasInt n1,
@@ -491,7 +492,7 @@ void AdjacentSchurExchange
 template<typename Real>
 void SchurExchange
 ( BlasInt n,
-  Real* T, BlasInt TLDim, 
+  Real* T, BlasInt TLDim,
   BlasInt j1,
   BlasInt j2,
   Real* work,
@@ -499,7 +500,7 @@ void SchurExchange
 template<typename Real>
 void SchurExchange
 ( BlasInt n,
-  Real* T, BlasInt TLDim, 
+  Real* T, BlasInt TLDim,
   Real* Q, BlasInt QLDim,
   BlasInt j1,
   BlasInt j2,
@@ -509,13 +510,13 @@ void SchurExchange
 template<typename Real>
 void SchurExchange
 ( BlasInt n,
-  Complex<Real>* T, BlasInt TLDim, 
+  Complex<Real>* T, BlasInt TLDim,
   BlasInt j1,
   BlasInt j2 );
 template<typename Real>
 void SchurExchange
 ( BlasInt n,
-  Complex<Real>* T, BlasInt TLDim, 
+  Complex<Real>* T, BlasInt TLDim,
   Complex<Real>* Q, BlasInt QLDim,
   BlasInt j1,
   BlasInt j2 );
@@ -552,7 +553,7 @@ void HessenbergSchur
 ( BlasInt n,
   float* H, BlasInt ldH,
   scomplex* w,
-  float* Q, BlasInt ldQ, 
+  float* Q, BlasInt ldQ,
   bool fullTriangle=true,
   bool multiplyQ=false,
   bool useAED=true );
@@ -560,7 +561,7 @@ void HessenbergSchur
 ( BlasInt n,
   double* H, BlasInt ldH,
   dcomplex* w,
-  double* Q, BlasInt ldQ, 
+  double* Q, BlasInt ldQ,
   bool fullTriangle=true,
   bool multiplyQ=false,
   bool useAED=true );
@@ -568,7 +569,7 @@ void HessenbergSchur
 ( BlasInt n,
   scomplex* H, BlasInt ldH,
   scomplex* w,
-  scomplex* Q, BlasInt ldQ, 
+  scomplex* Q, BlasInt ldQ,
   bool fullTriangle=false,
   bool multiplyQ=false,
   bool useAED=true );
@@ -576,7 +577,7 @@ void HessenbergSchur
 ( BlasInt n,
   dcomplex* H, BlasInt ldH,
   dcomplex* w,
-  dcomplex* Q, BlasInt ldQ, 
+  dcomplex* Q, BlasInt ldQ,
   bool fullTriangle=false,
   bool multiplyQ=false,
   bool useAED=true );
@@ -623,28 +624,28 @@ void Schur
 ( BlasInt n,
   float* A, BlasInt ldA,
   scomplex* w,
-  float* Q, BlasInt ldQ, 
+  float* Q, BlasInt ldQ,
   bool fullTriangle=true,
   bool time=false );
 void Schur
 ( BlasInt n,
   double* A, BlasInt ldA,
   dcomplex* w,
-  double* Q, BlasInt ldQ, 
+  double* Q, BlasInt ldQ,
   bool fullTriangle=true,
   bool time=false );
 void Schur
 ( BlasInt n,
   scomplex* A, BlasInt ldA,
   scomplex* w,
-  scomplex* Q, BlasInt ldQ, 
+  scomplex* Q, BlasInt ldQ,
   bool fullTriangle=true,
   bool time=false );
 void Schur
 ( BlasInt n,
   dcomplex* A, BlasInt ldA,
   dcomplex* w,
-  dcomplex* Q, BlasInt ldQ, 
+  dcomplex* Q, BlasInt ldQ,
   bool fullTriangle=true,
   bool time=false );
 
@@ -700,41 +701,42 @@ void Eig
   bool time=false );
 
 void Eig
-( BlasInt n, 
+( BlasInt n,
   float* A, BlasInt ldA,
   scomplex* w,
   scomplex* X, BlasInt ldX,
   bool time=false );
 void Eig
-( BlasInt n, 
+( BlasInt n,
   float* A, BlasInt ldA,
   scomplex* w,
   float* XPacked, BlasInt ldX,
   bool time=false );
 void Eig
-( BlasInt n, 
+( BlasInt n,
   double* A, BlasInt ldA,
   dcomplex* w,
   dcomplex* X, BlasInt ldX,
   bool time=false );
 void Eig
-( BlasInt n, 
+( BlasInt n,
   double* A, BlasInt ldA,
   dcomplex* w,
   double* XPacked, BlasInt ldX,
   bool time=false );
 void Eig
-( BlasInt n, 
+( BlasInt n,
   scomplex* A, BlasInt ldA,
   scomplex* w,
   scomplex* X, BlasInt ldX,
   bool time=false );
 void Eig
-( BlasInt n, 
+( BlasInt n,
   dcomplex* A, BlasInt ldA,
   dcomplex* w,
   dcomplex* X, BlasInt ldX,
   bool time=false );
+#endif // HYDROGEN_USE_LAPACK
 
 } // namespace lapack
 

--- a/include/El/core/imports/lapack.hpp
+++ b/include/El/core/imports/lapack.hpp
@@ -20,7 +20,7 @@ void Copy
 ( char uplo, BlasInt m, BlasInt n,
   const T* A, BlasInt lda, T* B, BlasInt ldb );
 
-#ifdef HYDROGEN_USE_LAPACK
+#ifdef HYDROGEN_HAVE_LAPACK
 void Copy
 ( char uplo, BlasInt m, BlasInt n,
   const float* A, BlasInt lda, float* B, BlasInt ldb );
@@ -736,7 +736,7 @@ void Eig
   dcomplex* w,
   dcomplex* X, BlasInt ldX,
   bool time=false );
-#endif // HYDROGEN_USE_LAPACK
+#endif // HYDROGEN_HAVE_LAPACK
 
 } // namespace lapack
 

--- a/src/core/imports/CMakeLists.txt
+++ b/src/core/imports/CMakeLists.txt
@@ -24,7 +24,9 @@ endif()
 
 # Add the subdirectories
 add_subdirectory(blas)
-add_subdirectory(lapack)
+if (HYDROGEN_HAVE_LAPACK)
+  add_subdirectory(lapack)
+endif ()
 add_subdirectory(mpfr)
 add_subdirectory(scalapack)
 

--- a/src/core/imports/blas/Nrm.hpp
+++ b/src/core/imports/blas/Nrm.hpp
@@ -2,26 +2,26 @@
    Copyright (c) 2009-2016, Jack Poulson
    All rights reserved.
 
-   This file is part of Elemental and is under the BSD 2-Clause License, 
-   which can be found in the LICENSE file in the root directory, or at 
+   This file is part of Elemental and is under the BSD 2-Clause License,
+   which can be found in the LICENSE file in the root directory, or at
    http://opensource.org/licenses/BSD-2-Clause
 */
 
 extern "C" {
 
 // To avoid the compatibility issue, we simply handroll our own complex dots
-float  EL_BLAS(snrm2) 
+float  EL_BLAS(snrm2)
 ( const BlasInt* n, const float   * x, const BlasInt* incx );
-double EL_BLAS(dnrm2) 
+double EL_BLAS(dnrm2)
 ( const BlasInt* n, const double  * x, const BlasInt* incx );
 float  EL_BLAS(scnrm2)
 ( const BlasInt* n, const scomplex* x, const BlasInt* incx );
 double EL_BLAS(dznrm2)
 ( const BlasInt* n, const dcomplex* x, const BlasInt* incx );
 
-float  EL_BLAS(sasum) 
+float  EL_BLAS(sasum)
 ( const BlasInt* n, const float   * x, const BlasInt* incx );
-double EL_BLAS(dasum) 
+double EL_BLAS(dasum)
 ( const BlasInt* n, const double  * x, const BlasInt* incx );
 float  EL_BLAS(scasum)
 ( const BlasInt* n, const scomplex* x, const BlasInt* incx );
@@ -41,7 +41,7 @@ template<typename F>
 Base<F> Nrm2( BlasInt n, const F* x, BlasInt incx )
 {
     typedef Base<F> Real;
-    Real scale = 0; 
+    Real scale = 0;
     Real scaledSquare = 1;
     for( BlasInt i=0; i<n; ++i )
         UpdateScaledSquare( x[i*incx], scale, scaledSquare );
@@ -114,7 +114,7 @@ Nrm1( BlasInt n, const Complex<BigFloat>* x, BlasInt incx );
 double Nrm1( BlasInt n, const double* x, BlasInt incx )
 { return EL_BLAS(dasum)( &n, x, &incx ); }
 double Nrm1( BlasInt n, const dcomplex* x, BlasInt incx )
-{ return EL_LAPACK(dzsum1)( &n, x, &incx ); }
+{ return EL_BLAS(dzasum)( &n, x, &incx ); }
 
 template<typename F>
 Base<F> NrmInf( BlasInt n, const F* x, BlasInt incx )

--- a/src/core/imports/blas/Symv.hpp
+++ b/src/core/imports/blas/Symv.hpp
@@ -2,8 +2,8 @@
    Copyright (c) 2009-2016, Jack Poulson
    All rights reserved.
 
-   This file is part of Elemental and is under the BSD 2-Clause License, 
-   which can be found in the LICENSE file in the root directory, or at 
+   This file is part of Elemental and is under the BSD 2-Clause License,
+   which can be found in the LICENSE file in the root directory, or at
    http://opensource.org/licenses/BSD-2-Clause
 */
 
@@ -61,7 +61,7 @@ template<typename T>
 void Hemv
 ( char uplo, BlasInt m,
   const T& alpha,
-  const T* A, BlasInt ALDim, 
+  const T* A, BlasInt ALDim,
   const T* x, BlasInt incx,
   const T& beta,
         T* y, BlasInt incy )
@@ -105,7 +105,7 @@ void Hemv
         }
 
         // Multiply with the adjoint of the strictly lower triangle
-        for( BlasInt j=0; j<m; ++j ) 
+        for( BlasInt j=0; j<m; ++j )
         {
             for( BlasInt i=j+1; i<m; ++i )
             {
@@ -131,7 +131,7 @@ void Hemv
         }
 
         // Multiply with the adjoint of the strictly upper triangle
-        for( BlasInt j=0; j<m; ++j ) 
+        for( BlasInt j=0; j<m; ++j )
         {
             for( BlasInt i=0; i<j; ++i )
             {
@@ -145,78 +145,78 @@ void Hemv
 }
 
 template void Hemv
-( char uplo, BlasInt m, 
+( char uplo, BlasInt m,
   const Int& alpha,
-  const Int* A, BlasInt ALDim, 
-  const Int* x, BlasInt incx, 
+  const Int* A, BlasInt ALDim,
+  const Int* x, BlasInt incx,
   const Int& beta,
         Int* y, BlasInt incy );
 #ifdef HYDROGEN_HAVE_QD
 template void Hemv
-( char uplo, BlasInt m, 
+( char uplo, BlasInt m,
   const DoubleDouble& alpha,
-  const DoubleDouble* A, BlasInt ALDim, 
-  const DoubleDouble* x, BlasInt incx, 
+  const DoubleDouble* A, BlasInt ALDim,
+  const DoubleDouble* x, BlasInt incx,
   const DoubleDouble& beta,
         DoubleDouble* y, BlasInt incy );
 template void Hemv
-( char uplo, BlasInt m, 
+( char uplo, BlasInt m,
   const QuadDouble& alpha,
-  const QuadDouble* A, BlasInt ALDim, 
-  const QuadDouble* x, BlasInt incx, 
+  const QuadDouble* A, BlasInt ALDim,
+  const QuadDouble* x, BlasInt incx,
   const QuadDouble& beta,
         QuadDouble* y, BlasInt incy );
 template void Hemv
-( char uplo, BlasInt m, 
+( char uplo, BlasInt m,
   const Complex<DoubleDouble>& alpha,
-  const Complex<DoubleDouble>* A, BlasInt ALDim, 
-  const Complex<DoubleDouble>* x, BlasInt incx, 
+  const Complex<DoubleDouble>* A, BlasInt ALDim,
+  const Complex<DoubleDouble>* x, BlasInt incx,
   const Complex<DoubleDouble>& beta,
         Complex<DoubleDouble>* y, BlasInt incy );
 template void Hemv
-( char uplo, BlasInt m, 
+( char uplo, BlasInt m,
   const Complex<QuadDouble>& alpha,
-  const Complex<QuadDouble>* A, BlasInt ALDim, 
-  const Complex<QuadDouble>* x, BlasInt incx, 
+  const Complex<QuadDouble>* A, BlasInt ALDim,
+  const Complex<QuadDouble>* x, BlasInt incx,
   const Complex<QuadDouble>& beta,
         Complex<QuadDouble>* y, BlasInt incy );
 #endif
 #ifdef HYDROGEN_HAVE_QUADMATH
 template void Hemv
-( char uplo, BlasInt m, 
+( char uplo, BlasInt m,
   const Quad& alpha,
-  const Quad* A, BlasInt ALDim, 
-  const Quad* x, BlasInt incx, 
+  const Quad* A, BlasInt ALDim,
+  const Quad* x, BlasInt incx,
   const Quad& beta,
         Quad* y, BlasInt incy );
 template void Hemv
-( char uplo, BlasInt m, 
+( char uplo, BlasInt m,
   const Complex<Quad>& alpha,
-  const Complex<Quad>* A, BlasInt ALDim, 
-  const Complex<Quad>* x, BlasInt incx, 
+  const Complex<Quad>* A, BlasInt ALDim,
+  const Complex<Quad>* x, BlasInt incx,
   const Complex<Quad>& beta,
         Complex<Quad>* y, BlasInt incy );
 #endif
 #ifdef HYDROGEN_HAVE_MPC
 template void Hemv
-( char uplo, BlasInt m, 
+( char uplo, BlasInt m,
   const BigInt& alpha,
-  const BigInt* A, BlasInt ALDim, 
-  const BigInt* x, BlasInt incx, 
+  const BigInt* A, BlasInt ALDim,
+  const BigInt* x, BlasInt incx,
   const BigInt& beta,
         BigInt* y, BlasInt incy );
 template void Hemv
-( char uplo, BlasInt m, 
+( char uplo, BlasInt m,
   const BigFloat& alpha,
-  const BigFloat* A, BlasInt ALDim, 
-  const BigFloat* x, BlasInt incx, 
+  const BigFloat* A, BlasInt ALDim,
+  const BigFloat* x, BlasInt incx,
   const BigFloat& beta,
         BigFloat* y, BlasInt incy );
 template void Hemv
-( char uplo, BlasInt m, 
+( char uplo, BlasInt m,
   const Complex<BigFloat>& alpha,
-  const Complex<BigFloat>* A, BlasInt ALDim, 
-  const Complex<BigFloat>* x, BlasInt incx, 
+  const Complex<BigFloat>* A, BlasInt ALDim,
+  const Complex<BigFloat>* x, BlasInt incx,
   const Complex<BigFloat>& beta,
         Complex<BigFloat>* y, BlasInt incy );
 #endif
@@ -224,7 +224,7 @@ template void Hemv
 void Hemv
 ( char uplo, BlasInt m,
   const float& alpha,
-  const float* A, BlasInt ALDim, 
+  const float* A, BlasInt ALDim,
   const float* x, BlasInt incx,
   const float& beta,
         float* y, BlasInt incy )
@@ -233,7 +233,7 @@ void Hemv
 void Hemv
 ( char uplo, BlasInt m,
   const double& alpha,
-  const double* A, BlasInt ALDim, 
+  const double* A, BlasInt ALDim,
   const double* x, BlasInt incx,
   const double& beta,
         double* y, BlasInt incy )
@@ -242,7 +242,7 @@ void Hemv
 void Hemv
 ( char uplo, BlasInt m,
   const scomplex& alpha,
-  const scomplex* A, BlasInt ALDim, 
+  const scomplex* A, BlasInt ALDim,
   const scomplex* x, BlasInt incx,
   const scomplex& beta,
         scomplex* y, BlasInt incy )
@@ -251,7 +251,7 @@ void Hemv
 void Hemv
 ( char uplo, BlasInt m,
   const dcomplex& alpha,
-  const dcomplex* A, BlasInt ALDim, 
+  const dcomplex* A, BlasInt ALDim,
   const dcomplex* x, BlasInt incx,
   const dcomplex& beta,
         dcomplex* y, BlasInt incy )
@@ -262,7 +262,7 @@ template<typename T>
 void Symv
 ( char uplo, BlasInt m,
   const T& alpha,
-  const T* A, BlasInt ALDim, 
+  const T* A, BlasInt ALDim,
   const T* x, BlasInt incx,
   const T& beta,
         T* y, BlasInt incy )
@@ -306,7 +306,7 @@ void Symv
         }
 
         // Multiply with the transpose of the strictly lower triangle
-        for( BlasInt j=0; j<m; ++j ) 
+        for( BlasInt j=0; j<m; ++j )
         {
             for( BlasInt i=j+1; i<m; ++i )
             {
@@ -332,7 +332,7 @@ void Symv
         }
 
         // Multiply with the transpose of the strictly upper triangle
-        for( BlasInt j=0; j<m; ++j ) 
+        for( BlasInt j=0; j<m; ++j )
         {
             for( BlasInt i=0; i<j; ++i )
             {
@@ -346,78 +346,78 @@ void Symv
 }
 
 template void Symv
-( char uplo, BlasInt m, 
+( char uplo, BlasInt m,
   const Int& alpha,
-  const Int* A, BlasInt ALDim, 
-  const Int* x, BlasInt incx, 
+  const Int* A, BlasInt ALDim,
+  const Int* x, BlasInt incx,
   const Int& beta,
         Int* y, BlasInt incy );
 #ifdef HYDROGEN_HAVE_QD
 template void Symv
-( char uplo, BlasInt m, 
+( char uplo, BlasInt m,
   const DoubleDouble& alpha,
-  const DoubleDouble* A, BlasInt ALDim, 
-  const DoubleDouble* x, BlasInt incx, 
+  const DoubleDouble* A, BlasInt ALDim,
+  const DoubleDouble* x, BlasInt incx,
   const DoubleDouble& beta,
         DoubleDouble* y, BlasInt incy );
 template void Symv
-( char uplo, BlasInt m, 
+( char uplo, BlasInt m,
   const QuadDouble& alpha,
-  const QuadDouble* A, BlasInt ALDim, 
-  const QuadDouble* x, BlasInt incx, 
+  const QuadDouble* A, BlasInt ALDim,
+  const QuadDouble* x, BlasInt incx,
   const QuadDouble& beta,
         QuadDouble* y, BlasInt incy );
 template void Symv
-( char uplo, BlasInt m, 
+( char uplo, BlasInt m,
   const Complex<DoubleDouble>& alpha,
-  const Complex<DoubleDouble>* A, BlasInt ALDim, 
-  const Complex<DoubleDouble>* x, BlasInt incx, 
+  const Complex<DoubleDouble>* A, BlasInt ALDim,
+  const Complex<DoubleDouble>* x, BlasInt incx,
   const Complex<DoubleDouble>& beta,
         Complex<DoubleDouble>* y, BlasInt incy );
 template void Symv
-( char uplo, BlasInt m, 
+( char uplo, BlasInt m,
   const Complex<QuadDouble>& alpha,
-  const Complex<QuadDouble>* A, BlasInt ALDim, 
-  const Complex<QuadDouble>* x, BlasInt incx, 
+  const Complex<QuadDouble>* A, BlasInt ALDim,
+  const Complex<QuadDouble>* x, BlasInt incx,
   const Complex<QuadDouble>& beta,
         Complex<QuadDouble>* y, BlasInt incy );
 #endif
 #ifdef HYDROGEN_HAVE_QUADMATH
 template void Symv
-( char uplo, BlasInt m, 
+( char uplo, BlasInt m,
   const Quad& alpha,
-  const Quad* A, BlasInt ALDim, 
-  const Quad* x, BlasInt incx, 
+  const Quad* A, BlasInt ALDim,
+  const Quad* x, BlasInt incx,
   const Quad& beta,
         Quad* y, BlasInt incy );
 template void Symv
-( char uplo, BlasInt m, 
+( char uplo, BlasInt m,
   const Complex<Quad>& alpha,
-  const Complex<Quad>* A, BlasInt ALDim, 
-  const Complex<Quad>* x, BlasInt incx, 
+  const Complex<Quad>* A, BlasInt ALDim,
+  const Complex<Quad>* x, BlasInt incx,
   const Complex<Quad>& beta,
         Complex<Quad>* y, BlasInt incy );
 #endif
 #ifdef HYDROGEN_HAVE_MPC
 template void Symv
-( char uplo, BlasInt m, 
+( char uplo, BlasInt m,
   const BigInt& alpha,
-  const BigInt* A, BlasInt ALDim, 
-  const BigInt* x, BlasInt incx, 
+  const BigInt* A, BlasInt ALDim,
+  const BigInt* x, BlasInt incx,
   const BigInt& beta,
         BigInt* y, BlasInt incy );
 template void Symv
-( char uplo, BlasInt m, 
+( char uplo, BlasInt m,
   const BigFloat& alpha,
-  const BigFloat* A, BlasInt ALDim, 
-  const BigFloat* x, BlasInt incx, 
+  const BigFloat* A, BlasInt ALDim,
+  const BigFloat* x, BlasInt incx,
   const BigFloat& beta,
         BigFloat* y, BlasInt incy );
 template void Symv
-( char uplo, BlasInt m, 
+( char uplo, BlasInt m,
   const Complex<BigFloat>& alpha,
-  const Complex<BigFloat>* A, BlasInt ALDim, 
-  const Complex<BigFloat>* x, BlasInt incx, 
+  const Complex<BigFloat>* A, BlasInt ALDim,
+  const Complex<BigFloat>* x, BlasInt incx,
   const Complex<BigFloat>& beta,
         Complex<BigFloat>* y, BlasInt incy );
 #endif
@@ -425,7 +425,7 @@ template void Symv
 void Symv
 ( char uplo, BlasInt m,
   const float& alpha,
-  const float* A, BlasInt ALDim, 
+  const float* A, BlasInt ALDim,
   const float* x, BlasInt incx,
   const float& beta,
         float* y, BlasInt incy )
@@ -434,16 +434,17 @@ void Symv
 void Symv
 ( char uplo, BlasInt m,
   const double& alpha,
-  const double* A, BlasInt ALDim, 
+  const double* A, BlasInt ALDim,
   const double* x, BlasInt incx,
   const double& beta,
         double* y, BlasInt incy )
 { EL_BLAS(dsymv)( &uplo, &m, &alpha, A, &ALDim, x, &incx, &beta, y, &incy ); }
 
+#ifdef HYDROGEN_USE_ESSL_WITH_LAPACK
 void Symv
 ( char uplo, BlasInt m,
   const scomplex& alpha,
-  const scomplex* A, BlasInt ALDim, 
+  const scomplex* A, BlasInt ALDim,
   const scomplex* x, BlasInt incx,
   const scomplex& beta,
         scomplex* y, BlasInt incy )
@@ -455,7 +456,7 @@ void Symv
 void Symv
 ( char uplo, BlasInt m,
   const dcomplex& alpha,
-  const dcomplex* A, BlasInt ALDim, 
+  const dcomplex* A, BlasInt ALDim,
   const dcomplex* x, BlasInt incx,
   const dcomplex& beta,
         dcomplex* y, BlasInt incy )
@@ -463,6 +464,7 @@ void Symv
     // Recall that 'zsymv' is an LAPACK auxiliary routine
     EL_LAPACK(zsymv)( &uplo, &m, &alpha, A, &ALDim, x, &incx, &beta, y, &incy );
 }
+#endif // HYDROGEN_USE_ESSL_WITH_LAPACK
 
 } // namespace blas
 } // namespace El

--- a/src/core/imports/blas/Symv.hpp
+++ b/src/core/imports/blas/Symv.hpp
@@ -440,7 +440,7 @@ void Symv
         double* y, BlasInt incy )
 { EL_BLAS(dsymv)( &uplo, &m, &alpha, A, &ALDim, x, &incx, &beta, y, &incy ); }
 
-#ifdef HYDROGEN_USE_ESSL_WITH_LAPACK
+#ifdef HYDROGEN_HAVE_LAPACK
 void Symv
 ( char uplo, BlasInt m,
   const scomplex& alpha,
@@ -464,7 +464,7 @@ void Symv
     // Recall that 'zsymv' is an LAPACK auxiliary routine
     EL_LAPACK(zsymv)( &uplo, &m, &alpha, A, &ALDim, x, &incx, &beta, y, &incy );
 }
-#endif // HYDROGEN_USE_ESSL_WITH_LAPACK
+#endif // HYDROGEN_HAVE_LAPACK
 
 } // namespace blas
 } // namespace El

--- a/src/core/imports/blas/Syr.hpp
+++ b/src/core/imports/blas/Syr.hpp
@@ -2,8 +2,8 @@
    Copyright (c) 2009-2016, Jack Poulson
    All rights reserved.
 
-   This file is part of Elemental and is under the BSD 2-Clause License, 
-   which can be found in the LICENSE file in the root directory, or at 
+   This file is part of Elemental and is under the BSD 2-Clause License,
+   which can be found in the LICENSE file in the root directory, or at
    http://opensource.org/licenses/BSD-2-Clause
 */
 
@@ -90,55 +90,55 @@ void Her
 template void Her
 ( char uplo, BlasInt m,
   const Int& alpha,
-  const Int* x, BlasInt incx, 
+  const Int* x, BlasInt incx,
         Int* A, BlasInt ALDim );
 #ifdef HYDROGEN_HAVE_QD
 template void Her
-( char uplo, BlasInt m, 
+( char uplo, BlasInt m,
   const DoubleDouble& alpha,
   const DoubleDouble* x, BlasInt incx,
         DoubleDouble* A, BlasInt ALDim );
 template void Her
-( char uplo, BlasInt m, 
+( char uplo, BlasInt m,
   const QuadDouble& alpha,
   const QuadDouble* x, BlasInt incx,
         QuadDouble* A, BlasInt ALDim );
 template void Her
-( char uplo, BlasInt m, 
+( char uplo, BlasInt m,
   const DoubleDouble& alpha,
   const Complex<DoubleDouble>* x, BlasInt incx,
         Complex<DoubleDouble>* A, BlasInt ALDim );
 template void Her
-( char uplo, BlasInt m, 
+( char uplo, BlasInt m,
   const QuadDouble& alpha,
   const Complex<QuadDouble>* x, BlasInt incx,
         Complex<QuadDouble>* A, BlasInt ALDim );
 #endif
 #ifdef HYDROGEN_HAVE_QUADMATH
 template void Her
-( char uplo, BlasInt m, 
+( char uplo, BlasInt m,
   const Quad& alpha,
   const Quad* x, BlasInt incx,
         Quad* A, BlasInt ALDim );
 template void Her
-( char uplo, BlasInt m, 
+( char uplo, BlasInt m,
   const Quad& alpha,
-  const Complex<Quad>* x, BlasInt incx, 
+  const Complex<Quad>* x, BlasInt incx,
         Complex<Quad>* A, BlasInt ALDim );
 #endif
 #ifdef HYDROGEN_HAVE_MPC
 template void Her
-( char uplo, BlasInt m, 
+( char uplo, BlasInt m,
   const BigInt& alpha,
   const BigInt* x, BlasInt incx,
         BigInt* A, BlasInt ALDim );
 template void Her
-( char uplo, BlasInt m, 
+( char uplo, BlasInt m,
   const BigFloat& alpha,
   const BigFloat* x, BlasInt incx,
         BigFloat* A, BlasInt ALDim );
 template void Her
-( char uplo, BlasInt m, 
+( char uplo, BlasInt m,
   const BigFloat& alpha,
   const Complex<BigFloat>* x, BlasInt incx,
         Complex<BigFloat>* A, BlasInt ALDim );
@@ -216,55 +216,55 @@ void Syr
 template void Syr
 ( char uplo, BlasInt m,
   const Int& alpha,
-  const Int* x, BlasInt incx, 
+  const Int* x, BlasInt incx,
         Int* A, BlasInt ALDim );
 #ifdef HYDROGEN_HAVE_QD
 template void Syr
-( char uplo, BlasInt m, 
+( char uplo, BlasInt m,
   const DoubleDouble& alpha,
   const DoubleDouble* x, BlasInt incx,
         DoubleDouble* A, BlasInt ALDim );
 template void Syr
-( char uplo, BlasInt m, 
+( char uplo, BlasInt m,
   const QuadDouble& alpha,
   const QuadDouble* x, BlasInt incx,
         QuadDouble* A, BlasInt ALDim );
 template void Syr
-( char uplo, BlasInt m, 
+( char uplo, BlasInt m,
   const Complex<DoubleDouble>& alpha,
   const Complex<DoubleDouble>* x, BlasInt incx,
         Complex<DoubleDouble>* A, BlasInt ALDim );
 template void Syr
-( char uplo, BlasInt m, 
+( char uplo, BlasInt m,
   const Complex<QuadDouble>& alpha,
   const Complex<QuadDouble>* x, BlasInt incx,
         Complex<QuadDouble>* A, BlasInt ALDim );
 #endif
 #ifdef HYDROGEN_HAVE_QUADMATH
 template void Syr
-( char uplo, BlasInt m, 
+( char uplo, BlasInt m,
   const Quad& alpha,
   const Quad* x, BlasInt incx,
         Quad* A, BlasInt ALDim );
 template void Syr
-( char uplo, BlasInt m, 
+( char uplo, BlasInt m,
   const Complex<Quad>& alpha,
-  const Complex<Quad>* x, BlasInt incx, 
+  const Complex<Quad>* x, BlasInt incx,
         Complex<Quad>* A, BlasInt ALDim );
 #endif
 #ifdef HYDROGEN_HAVE_MPC
 template void Syr
-( char uplo, BlasInt m, 
+( char uplo, BlasInt m,
   const BigInt& alpha,
   const BigInt* x, BlasInt incx,
         BigInt* A, BlasInt ALDim );
 template void Syr
-( char uplo, BlasInt m, 
+( char uplo, BlasInt m,
   const BigFloat& alpha,
   const BigFloat* x, BlasInt incx,
         BigFloat* A, BlasInt ALDim );
 template void Syr
-( char uplo, BlasInt m, 
+( char uplo, BlasInt m,
   const Complex<BigFloat>& alpha,
   const Complex<BigFloat>* x, BlasInt incx,
         Complex<BigFloat>* A, BlasInt ALDim );
@@ -284,6 +284,7 @@ void Syr
         double* A, BlasInt ALDim )
 { EL_BLAS(dsyr)( &uplo, &m, &alpha, x, &incx, A, &ALDim ); }
 
+#ifdef HYDROGEN_USE_LAPACK
 void Syr
 ( char uplo, BlasInt m,
   const scomplex& alpha,
@@ -291,7 +292,7 @@ void Syr
         scomplex* A, BlasInt ALDim )
 {
     // Recall that 'csyr' is an LAPACK auxiliary routine
-    EL_LAPACK(csyr)( &uplo, &m, &alpha, x, &incx, A, &ALDim ); 
+    EL_LAPACK(csyr)( &uplo, &m, &alpha, x, &incx, A, &ALDim );
 }
 
 void Syr
@@ -301,8 +302,9 @@ void Syr
         dcomplex* A, BlasInt ALDim )
 {
     // Recall that 'zsyr' is an LAPACK auxiliary routine
-    EL_LAPACK(zsyr)( &uplo, &m, &alpha, x, &incx, A, &ALDim ); 
+    EL_LAPACK(zsyr)( &uplo, &m, &alpha, x, &incx, A, &ALDim );
 }
+#endif // HYDROGEN_USE_LAPACK
 
 } // namespace blas
 } // namespace El

--- a/src/core/imports/blas/Syr.hpp
+++ b/src/core/imports/blas/Syr.hpp
@@ -284,7 +284,7 @@ void Syr
         double* A, BlasInt ALDim )
 { EL_BLAS(dsyr)( &uplo, &m, &alpha, x, &incx, A, &ALDim ); }
 
-#ifdef HYDROGEN_USE_LAPACK
+#ifdef HYDROGEN_HAVE_LAPACK
 void Syr
 ( char uplo, BlasInt m,
   const scomplex& alpha,
@@ -304,7 +304,7 @@ void Syr
     // Recall that 'zsyr' is an LAPACK auxiliary routine
     EL_LAPACK(zsyr)( &uplo, &m, &alpha, x, &incx, A, &ALDim );
 }
-#endif // HYDROGEN_USE_LAPACK
+#endif // HYDROGEN_HAVE_LAPACK
 
 } // namespace blas
 } // namespace El

--- a/src/core/imports/lapack.cpp
+++ b/src/core/imports/lapack.cpp
@@ -385,6 +385,20 @@ template void Copy
         Complex<BigFloat>* B, BlasInt ldb );
 #endif
 
+template void Copy
+( char uplo, BlasInt m, BlasInt n,
+  const float* A, BlasInt lda, float* B, BlasInt ldb );
+template void Copy
+( char uplo, BlasInt m, BlasInt n,
+  const double* A, BlasInt lda, double* B, BlasInt ldb );
+template void Copy
+( char uplo, BlasInt m, BlasInt n,
+  const scomplex* A, BlasInt lda, scomplex* B, BlasInt ldb );
+template void Copy
+( char uplo, BlasInt m, BlasInt n,
+  const dcomplex* A, BlasInt lda, dcomplex* B, BlasInt ldb );
+
+#ifdef HYDROGEN_USE_ESSL_WITH_LAPACK
 void Copy
 ( char uplo, BlasInt m, BlasInt n,
   const float* A, BlasInt lda, float* B, BlasInt ldb )
@@ -705,7 +719,6 @@ template void ApplyReflector
 
 // Compute the EVD of a symmetric tridiagonal matrix
 // =================================================
-
 BlasInt SymmetricTridiagEigWrapper
 ( char job,
   char range,
@@ -4618,9 +4631,12 @@ void Schur
     else if( info > 0 )
         RuntimeError("chseqr's failed to compute all eigenvalues");
 }
+#endif // HYDROGEN_USE_ESSL_WITH_LAPACK
 
 } // namespace lapack
 } // namespace El
 
+#ifdef HYDROGEN_USE_ESSL_WITH_LAPACK
 #include "./lapack/TriangEig.hpp"
 #include "./lapack/Schur.hpp"
+#endif // HYDROGEN_USE_ESSL_WITH_LAPACK

--- a/src/core/imports/lapack.cpp
+++ b/src/core/imports/lapack.cpp
@@ -385,6 +385,8 @@ template void Copy
         Complex<BigFloat>* B, BlasInt ldb );
 #endif
 
+#ifndef HYDROGEN_HAVE_LAPACK
+
 template void Copy
 ( char uplo, BlasInt m, BlasInt n,
   const float* A, BlasInt lda, float* B, BlasInt ldb );
@@ -398,7 +400,8 @@ template void Copy
 ( char uplo, BlasInt m, BlasInt n,
   const dcomplex* A, BlasInt lda, dcomplex* B, BlasInt ldb );
 
-#ifdef HYDROGEN_USE_ESSL_WITH_LAPACK
+#else
+
 void Copy
 ( char uplo, BlasInt m, BlasInt n,
   const float* A, BlasInt lda, float* B, BlasInt ldb )
@@ -4631,12 +4634,12 @@ void Schur
     else if( info > 0 )
         RuntimeError("chseqr's failed to compute all eigenvalues");
 }
-#endif // HYDROGEN_USE_ESSL_WITH_LAPACK
+#endif // HYDROGEN_HAVE_LAPACK
 
 } // namespace lapack
 } // namespace El
 
-#ifdef HYDROGEN_USE_ESSL_WITH_LAPACK
+#ifdef HYDROGEN_HAVE_LAPACK
 #include "./lapack/TriangEig.hpp"
 #include "./lapack/Schur.hpp"
-#endif // HYDROGEN_USE_ESSL_WITH_LAPACK
+#endif // HYDROGEN_HAVE_LAPACK


### PR DESCRIPTION
If sufficient LAPACK support isn't found, use fallback implementations.

The only LAPACK function currently used by Hydrogen is {sdcz}lacpy, and it's not clear to me that this will be significantly better optimized than a simple openmp-parallelized doubly-nested for-loop, which, coincidentally, is the fallback implementation. Also unclear to me is how impactful this will be to our performance, since the problem machines are all GPU machines on which we would be less likely to hit the CPU implementation.