### PR TITLE
Avoid unnecessary memory allocation during matrix resize.

### DIFF
--- a/include/El/core/AbstractMatrix.hpp
+++ b/include/El/core/AbstractMatrix.hpp
@@ -267,13 +267,17 @@ template <typename T>
 inline void AbstractMatrix<T>::Resize_(
     Int height, Int width, Int leadingDimension)
 {
-    if (height != this->Height()
-        || width != this->Width()
+    if (height > this->Height()
+        || width > this->Width()
         || leadingDimension != this->LDim())
     {
-        this->SetSize_(height, width, leadingDimension);
+        this->Empty(false);
     }
-    do_resize_();
+    this->SetSize_(height, width, leadingDimension);
+    if (!this->Viewing())
+    {
+        do_resize_();
+    }
 }
 
 template <typename T>


### PR DESCRIPTION
This is to handle an edge case where the `Resize()` function is called for a matrix view and no resizing is needed. We can now copy into matrix views.