### PR TITLE
remove pmrrr and suite_sparse from the hydrogen build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -275,14 +275,6 @@ include(FindAndVerifyMPI)
 include(FindAndVerifyLAPACK)
 include(FindAndVerifyExtendedPrecision)
 
-# External projects build internally
-# TODO Investigate why
-add_subdirectory(external/pmrrr)
-
-# Add SuiteSparse (TODO: Why bundled here?)
-add_subdirectory(external/suite_sparse)
-include_directories(external/suite_sparse/include)
-
 # Macro for setting up full paths
 macro(set_full_path VAR)
   unset(__tmp_names)
@@ -318,7 +310,6 @@ endif ()
 if (TARGET OpenMP::OpenMP_CXX)
   target_link_libraries(${PROJECT_NAME} PUBLIC OpenMP::OpenMP_CXX)
 endif ()
-target_link_libraries(${PROJECT_NAME} PUBLIC pmrrr)
 target_link_libraries(${PROJECT_NAME} PUBLIC MPI::MPI_CXX)
 target_link_libraries(${PROJECT_NAME} PUBLIC LAPACK::lapack)
 target_link_libraries(${PROJECT_NAME} PUBLIC EP::extended_precision)

--- a/include/El/core.hpp
+++ b/include/El/core.hpp
@@ -250,7 +250,6 @@ template<typename T> struct IsStdField<Complex<T>>
 #include <El/core/imports/flame.hpp>
 #include <El/core/imports/mkl.hpp>
 #include <El/core/imports/openblas.hpp>
-#include <El/core/imports/pmrrr.hpp>
 #include <El/core/imports/scalapack.hpp>
 
 #include <El/core/limits.hpp>

--- a/include/El/core/imports/CMakeLists.txt
+++ b/include/El/core/imports/CMakeLists.txt
@@ -13,11 +13,9 @@ set_full_path(THIS_DIR_HEADERS
   mpi_choice.hpp
   omp.hpp
   openblas.hpp
-#  pmrrr.hpp
   qd.hpp
   qt5.hpp
   scalapack.hpp
-  suite_sparse.hpp
   valgrind.hpp
   )
 

--- a/src/core/imports/CMakeLists.txt
+++ b/src/core/imports/CMakeLists.txt
@@ -7,7 +7,6 @@ set_full_path(THIS_DIR_SOURCES
   mpfr.cpp
   mpi.cpp
   openblas.cpp
-  pmrrr.cpp
   qd.cpp
   qt5.cpp
   scalapack.cpp


### PR DESCRIPTION
the source code for these dependencies is not removed or
changed. However, the imports are no longer included in Hydrogen and
they are not build/included/linked in any way. We do not utilize these
features.