### PR TITLE
Revert "Avoid unnecessary memory allocation during matrix resize."

### DIFF
--- a/include/El/core/AbstractMatrix.hpp
+++ b/include/El/core/AbstractMatrix.hpp
@@ -267,17 +267,13 @@ template <typename T>
 inline void AbstractMatrix<T>::Resize_(
     Int height, Int width, Int leadingDimension)
 {
-    if (height > this->Height()
-        || width > this->Width()
+    if (height != this->Height()
+        || width != this->Width()
         || leadingDimension != this->LDim())
     {
-        this->Empty(false);
+        this->SetSize_(height, width, leadingDimension);
     }
-    this->SetSize_(height, width, leadingDimension);
-    if (!this->Viewing())
-    {
-        do_resize_();
-    }
+    do_resize_();
 }
 
 template <typename T>


### PR DESCRIPTION
Reverts LLNL/Elemental#30.

This caused a problem in the Gemm test.