### PR TITLE
Restoring #30.

### DIFF
--- a/include/El/core/AbstractMatrix.hpp
+++ b/include/El/core/AbstractMatrix.hpp
@@ -267,13 +267,17 @@ template <typename T>
 inline void AbstractMatrix<T>::Resize_(
     Int height, Int width, Int leadingDimension)
 {
-    if (height != this->Height()
-        || width != this->Width()
+    if (height > this->Height()
+        || width > this->Width()
         || leadingDimension != this->LDim())
     {
-        this->SetSize_(height, width, leadingDimension);
+        this->Empty_(false);
     }
-    do_resize_();
+    this->SetSize_(height, width, leadingDimension);
+    if (!this->Viewing())
+    {
+        do_resize_();
+    }
 }
 
 template <typename T>


### PR DESCRIPTION
This reverts #33. We get around the runtime errors by calling `AbstractMatrix::Empty_(bool)` instead of `AbstractMatrix::Empty(bool)`. Things look reasonable when I run tests/Gemm on 4 Pascal nodes.