### PR TITLE
Use utility macro for matrix instantiation function.

### DIFF
--- a/include/El/core/DistMatrix/Abstract.hpp
+++ b/include/El/core/DistMatrix/Abstract.hpp
@@ -303,6 +303,7 @@ public:
     (const El::Grid& grid=Grid::Default(), int root=0,
      Dist colDist=MC, Dist rowDist=MR, DistWrap wrap=ELEMENT,
      Device dev=Device::CPU);
+    static type* Instantiate(const El::DistData& data);
   
 private:
     // Member variables

--- a/src/core/DistMatrix/Abstract.cpp
+++ b/src/core/DistMatrix/Abstract.cpp
@@ -455,28 +455,18 @@ AbstractDistMatrix<T>::AssertSameSize(Int height, Int width) const
 namespace
 {
 
-template<typename T, DistWrap wrap, Device dev>
+template<typename T>
 AbstractDistMatrix<T>*
-Instantiate_(const El::Grid& grid, int root, Dist colDist, Dist rowDist)
+Instantiate_
+(const El::Grid& grid, int root,
+ Dist colDist, Dist rowDist, DistWrap wrap, Device dev)
 {
-#define EL_DISTMATRIX_INSTANTIATE(U, V)                         \
-    if(colDist == U && rowDist == V)                            \
-        return new DistMatrix<T,U,V,wrap,dev>(grid, root);
-    EL_DISTMATRIX_INSTANTIATE(CIRC, CIRC)
-    EL_DISTMATRIX_INSTANTIATE(MC,   MR)
-    EL_DISTMATRIX_INSTANTIATE(MC,   STAR)
-    EL_DISTMATRIX_INSTANTIATE(MD,   STAR)
-    EL_DISTMATRIX_INSTANTIATE(MR,   MC)
-    EL_DISTMATRIX_INSTANTIATE(MR,   STAR)
-    EL_DISTMATRIX_INSTANTIATE(STAR, MC)
-    EL_DISTMATRIX_INSTANTIATE(STAR, MD)
-    EL_DISTMATRIX_INSTANTIATE(STAR, MR)
-    EL_DISTMATRIX_INSTANTIATE(STAR, STAR)
-    EL_DISTMATRIX_INSTANTIATE(STAR, VC)
-    EL_DISTMATRIX_INSTANTIATE(STAR, VR)
-    EL_DISTMATRIX_INSTANTIATE(VC,   STAR)
-    EL_DISTMATRIX_INSTANTIATE(VR,   STAR)
-#undef EL_DISTMATRIX_INSTANTIATE
+#define GUARD(CDIST,RDIST,WRAP,DEVICE)                          \
+    (colDist == CDIST) && (rowDist == RDIST) && (wrap == WRAP)  \
+        && (dev == DEVICE)
+#define PAYLOAD(CDIST,RDIST,WRAP,DEVICE)                                \
+    return new DistMatrix<T,CDIST,RDIST,WRAP,DEVICE>(grid, root);
+#include "El/macros/DeviceGuardAndPayload.h"
     LogicError
     ("Invalid template arguments for DistMatrix "
      "(colDist=",Int(colDist),", rowDist=",Int(rowDist),", "
@@ -492,16 +482,7 @@ AbstractDistMatrix<T>::Instantiate
 (const El::Grid& grid, int root,
  Dist colDist, Dist rowDist, DistWrap wrap, Device dev)
 {
-#define EL_DISTMATRIX_INSTANTIATE(TWrap, TDev)                          \
-    if(wrap == TWrap && dev == TDev)                                    \
-        return Instantiate_<T,TWrap,TDev>(grid, root, colDist, rowDist);
-    EL_DISTMATRIX_INSTANTIATE(ELEMENT, Device::CPU)
-    EL_DISTMATRIX_INSTANTIATE(BLOCK,   Device::CPU)
-#undef EL_DISTMATRIX_INSTANTIATE
-    LogicError
-    ("Invalid template arguments for DistMatrix "
-     "(colDist=",Int(colDist),", rowDist=",Int(rowDist),", "
-     "wrap=",Int(wrap),", dev=",Int(dev),")");
+    LogicError("Invalid type for DistMatrix");
     return nullptr;
 }
 
@@ -511,20 +492,7 @@ AbstractDistMatrix<float>::Instantiate
 (const El::Grid& grid, int root,
  Dist colDist, Dist rowDist, DistWrap wrap, Device dev)
 {
-#define EL_DISTMATRIX_INSTANTIATE(TWrap, TDev)                          \
-    if(wrap == TWrap && dev == TDev)                                    \
-        return Instantiate_<float,TWrap,TDev>(grid, root, colDist, rowDist);
-    EL_DISTMATRIX_INSTANTIATE(ELEMENT, Device::CPU)
-    EL_DISTMATRIX_INSTANTIATE(BLOCK,   Device::CPU)
-#ifdef HYDROGEN_HAVE_CUDA
-    EL_DISTMATRIX_INSTANTIATE(ELEMENT, Device::GPU)
-#endif // HYDROGEN_HAVE_CUDA
-#undef EL_DISTMATRIX_INSTANTIATE
-    LogicError
-    ("Invalid template arguments for DistMatrix "
-     "(colDist=",Int(colDist),", rowDist=",Int(rowDist),", "
-     "wrap=",Int(wrap),", dev=",Int(dev),")");
-    return nullptr;
+    return Instantiate_<float>(grid, root, colDist, rowDist, wrap, dev);
 }
 
 template<>
@@ -533,20 +501,19 @@ AbstractDistMatrix<double>::Instantiate
 (const El::Grid& grid, int root,
  Dist colDist, Dist rowDist, DistWrap wrap, Device dev)
 {
-#define EL_DISTMATRIX_INSTANTIATE(TWrap, TDev)                          \
-    if(wrap == TWrap && dev == TDev)                                    \
-        return Instantiate_<double,TWrap,TDev>(grid, root, colDist, rowDist);
-    EL_DISTMATRIX_INSTANTIATE(ELEMENT, Device::CPU)
-    EL_DISTMATRIX_INSTANTIATE(BLOCK,   Device::CPU)
-#ifdef HYDROGEN_HAVE_CUDA
-    EL_DISTMATRIX_INSTANTIATE(ELEMENT, Device::GPU)
-#endif // HYDROGEN_HAVE_CUDA
-#undef EL_DISTMATRIX_INSTANTIATE
-    LogicError
-    ("Invalid template arguments for DistMatrix "
-     "(colDist=",Int(colDist),", rowDist=",Int(rowDist),", "
-     "wrap=",Int(wrap),", dev=",Int(dev),")");
-    return nullptr;
+    return Instantiate_<double>(grid, root, colDist, rowDist, wrap, dev);
+}
+
+template<typename T>
+AbstractDistMatrix<T>*
+AbstractDistMatrix<T>::Instantiate(const El::DistData& data)
+{
+    const DistWrap wrap = ((data.blockHeight == 1
+                            && data.blockWidth == 1) ?
+                           ELEMENT : BLOCK);
+    return AbstractDistMatrix<T>::Instantiate
+           (*data.grid, data.root,
+            data.colDist, data.rowDist, wrap, data.device);
 }
 
 // Private section


### PR DESCRIPTION
This is a little cleaner and will make it easier when we support matrices with more datatypes, e.g. `Int` or complex datatypes. This also adds a matrix instantiation function that takes a DistData struct.