### PR TITLE
Allowing copy between local matrices on different devices.

### DIFF
--- a/include/El/blas_like/level1/Copy.hpp
+++ b/include/El/blas_like/level1/Copy.hpp
@@ -22,8 +22,6 @@ namespace El {
 template <typename T>
 void Copy(AbstractMatrix<T> const& A, AbstractMatrix<T>& B)
 {
-    if (A.GetDevice() != B.GetDevice())
-        LogicError("Copy: A and B must be on same device for now.");
     switch (A.GetDevice())
     {
     case Device::CPU:


### PR DESCRIPTION
We throw an unnecessary exception, probably from an earlier version of the code. Things work well for me if I just delete this check.