### PR TITLE
Fixing bug when copying between unaligned matrices.

### DIFF
--- a/include/El/blas_like/level1/Copy/Translate.hpp
+++ b/include/El/blas_like/level1/Copy/Translate.hpp
@@ -115,13 +115,10 @@ void Translate(
         // Unpack -- buffer is on D1, B is on D2
         if(crossRank == B.Root())
         {
-            // FIXME
-            simple_buffer<T,D2> tmpbuffer(buffer.size());
-
-            util::InterleaveMatrix(
-                localHeightB, localWidthB,
-                tmpbuffer.data(), 1, localHeightB,
-                B.Buffer(),    1, B.LDim(), syncInfoB);
+            Matrix<T,D1> BPacked(
+                localHeightB, localWidthB, buffer.data(), localHeightB);
+            SetSyncInfo(BPacked, syncInfoA);
+            Copy(BPacked, B.Matrix());
         }
     }
 }


### PR DESCRIPTION
I ran into problems when copying between two distributed matrices with the same distribution but different alignments. Based on my understanding of the code, the stack looks like:
- `Copy`
- `DistMatrix<T,U,V,Dev>::operator=`
- `copy::Translate`

These changes should play nice with #46.