### PR TITLE
GPUManager accessors no longer change CUDA or cuBLAS state.

### DIFF
--- a/src/core/imports/cuda.cpp
+++ b/src/core/imports/cuda.cpp
@@ -136,9 +136,6 @@ GPUManager* GPUManager::Instance()
 {
     if (!instance_)
         Create();
-
-    EL_CHECK_CUDA(
-        cudaSetDevice(instance_->device_));
     return instance_.get();
 }
 
@@ -197,13 +194,7 @@ void GPUManager::SynchronizeDevice( bool checkError )
 
 cublasHandle_t GPUManager::cuBLASHandle()
 {
-    auto* instance = Instance();
-    auto handle = instance->cublasHandle_;
-    EL_CHECK_CUBLAS(
-        cublasSetStream(handle, instance->stream_));
-    EL_CHECK_CUBLAS(
-        cublasSetPointerMode(handle, CUBLAS_POINTER_MODE_HOST));
-    return handle;
+    return Instance()->cublasHandle_;
 }
 
 } // namespace El


### PR DESCRIPTION
Previously, calling `GPUManager::Instance()` would reset the active CUDA device and calling `GPUManager::cuBLASHandle()` would reset the cuBLAS stream and pointer mode. This protected against the user doing something weird with non-default CUDA devices and streams, but it's also a non-obvious side effect. It also increases the number of CUDA API calls we make, with all the associated latency costs. I propose we make these functions more naive.