### PR TITLE
Remove debug message when calling Aluminum gather.

### DIFF
--- a/src/core/imports/mpi/Gather.hpp
+++ b/src/core/imports/mpi/Gather.hpp
@@ -35,7 +35,6 @@ void Gather(
                                      syncInfo.event_);
 
     auto multisync = MakeMultiSync(alSyncInfo, syncInfo);
-    std::cout << "ALUMINUM GATHER" << std::endl;
     Al::Gather<Backend>(
         sbuf, rbuf, sc, root, comm.template GetComm<Backend>());
 }


### PR DESCRIPTION
We print "ALUMINUM GATHER" before each call into an Aluminum GPU gather.