### PR TITLE
Matrices force leading dim to be greater than zero

### DIFF
--- a/include/El/core/AbstractMatrix.hpp
+++ b/include/El/core/AbstractMatrix.hpp
@@ -260,8 +260,9 @@ inline void AbstractMatrix<T>::Resize(
     Int height, Int width, Int leadingDimension)
 {
     EL_DEBUG_CSE
+        leadingDimension = Max(leadingDimension,1);
 #ifndef EL_RELEASE
-        AssertValidDimensions(height, width, leadingDimension);
+    AssertValidDimensions(height, width, leadingDimension);
     if (this->FixedSize() &&
         (height != height_ || width != this->Width() ||
          leadingDimension != leadingDimension_))
@@ -289,6 +290,7 @@ template <typename T>
 inline void AbstractMatrix<T>::Resize_(
     Int height, Int width, Int leadingDimension)
 {
+    leadingDimension = Max(leadingDimension,1);
     if (height > this->Height()
         || width > this->Width()
         || leadingDimension != this->LDim())
@@ -320,8 +322,8 @@ inline void AbstractMatrix<T>::AssertValidDimensions(
             LogicError("Height and width must be non-negative");
     if (leadingDimension < height)
         LogicError("Leading dimension must be no less than height");
-    if (leadingDimension == 0)
-        LogicError("Leading dimension cannot be zero (for BLAS compatibility)");
+    if (leadingDimension <= 0)
+        LogicError("Leading dimension must be greater than zero (for BLAS compatibility)");
 }
 
 template <typename T>
@@ -347,11 +349,14 @@ AbstractMatrix<T>::AbstractMatrix(Int height, Int width, Int ldim)
 template <typename T>
 AbstractMatrix<T>::AbstractMatrix(
     El::ViewType view, Int height, Int width, Int ldim)
-    : viewType_{view}, height_{height}, width_{width}, leadingDimension_{ldim}
+    : viewType_{view},
+      height_{height}, width_{width}, leadingDimension_{Max(ldim,1)}
 {
     EL_DEBUG_CSE
-        EL_DEBUG_ONLY(AssertValidDimensions(height, width, ldim))
-        }
+        EL_DEBUG_ONLY(AssertValidDimensions(this->Height(),
+                                            this->Width(),
+                                            this->LDim()))
+            }
 
 template <typename T>
 inline void AbstractMatrix<T>::SetSize_(
@@ -359,7 +364,7 @@ inline void AbstractMatrix<T>::SetSize_(
 {
     height_ = height;
     width_ = width;
-    leadingDimension_ = leadingDimension;
+    leadingDimension_ = Max(leadingDimension,1);
 }
 
 // Single-entry manipulation

--- a/include/El/core/Matrix/impl_cpu.hpp
+++ b/include/El/core/Matrix/impl_cpu.hpp
@@ -23,18 +23,18 @@ Matrix<Ring, Device::CPU>::Matrix() { }
 
 template<typename Ring>
 Matrix<Ring, Device::CPU>::Matrix(Int height, Int width)
-    : AbstractMatrix<Ring>{height,width,Max(height,1)}
+    : AbstractMatrix<Ring>{height,width,height}
 {
-    memory_.Require(Max(height,1) * width);
+    memory_.Require(this->LDim()*this->Width());
     data_ = memory_.Buffer();
     // TODO(poulson): Consider explicitly zeroing
 }
 
 template<typename Ring>
 Matrix<Ring, Device::CPU>::Matrix(Int height, Int width, Int leadingDimension)
-    : AbstractMatrix<Ring>{height, width, leadingDimension}
+    : AbstractMatrix<Ring>{height,width,leadingDimension}
 {
-    memory_.Require(leadingDimension*width);
+    memory_.Require(this->LDim()*this->Width());
     data_ = memory_.Buffer();
 }
 

--- a/include/El/core/Matrix/impl_gpu.hpp
+++ b/include/El/core/Matrix/impl_gpu.hpp
@@ -22,17 +22,17 @@ Matrix<Ring, Device::GPU>::Matrix() { }
 
 template<typename Ring>
 Matrix<Ring, Device::GPU>::Matrix(Int height, Int width)
-    : AbstractMatrix<Ring>{height, width, Max(height,1)}
+    : AbstractMatrix<Ring>{height,width,height}
 {
-    memory_.Require(this->LDim() * width);
+    memory_.Require(this->LDim()*this->Width());
     data_ = memory_.Buffer();
 }
 
 template<typename Ring>
 Matrix<Ring, Device::GPU>::Matrix(Int height, Int width, Int leadingDimension)
-    : AbstractMatrix<Ring>{height, width, leadingDimension}
+    : AbstractMatrix<Ring>{height,width,leadingDimension}
 {
-    memory_.Require(leadingDimension*width);
+    memory_.Require(this->LDim()*this->Width());
     data_ = memory_.Buffer();
 }
 


### PR DESCRIPTION
Running with the debug build, we observe that some distributed matrix copies are failing. Our hypothesis is that if the distributed matrices are small enough, some local matrices are empty and are initialized with a leading dimension of zero, which is considered invalid. This PR goes through the local matrix classes to make sure that leading dimensions are always at least 1.

@samadejacobs Does this resolve the errors?