### PR TITLE
update to cuda toolkit handling to fix cuda 10

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -295,10 +295,17 @@ if (${PROJECT_NAME}_ENABLE_CUDA)
 
       add_library(cuda::toolkit INTERFACE IMPORTED)
 
+      foreach (lib IN LISTS CUDA_CUBLAS_LIBRARIES CUDA_LIBRARIES
+          CUDA_CUDA_LIBRARY CUB_LIBRARIES NVML_LIBRARIES)
+
+        if (lib)
+          list(APPEND _CUDA_TOOLKIT_LIBS ${lib})
+        endif ()
+
+      endforeach ()
+
       set_property(TARGET cuda::toolkit PROPERTY
-        INTERFACE_LINK_LIBRARIES
-        "${CUDA_CUBLAS_LIBRARIES}" "${CUDA_LIBRARIES}" "${CUDA_CUDA_LIBRARY}"
-        "${CUB_LIBRARIES}" "${NVML_LIBRARIES}")
+        INTERFACE_LINK_LIBRARIES "${_CUDA_TOOLKIT_LIBS}")
 
       set_property(TARGET cuda::toolkit PROPERTY
         INTERFACE_COMPILE_OPTIONS $<$<COMPILE_LANGUAGE:CUDA>:-arch=sm_30>)

--- a/cmake/configure_files/HydrogenConfig.cmake.in
+++ b/cmake/configure_files/HydrogenConfig.cmake.in
@@ -80,10 +80,17 @@ if (_HYDROGEN_HAVE_CUDA)
     add_library(cuda::toolkit INTERFACE IMPORTED)
   endif ()
 
+  foreach (lib IN LISTS CUDA_CUBLAS_LIBRARIES CUDA_LIBRARIES
+      CUDA_CUDA_LIBRARY CUB_LIBRARIES NVML_LIBRARIES)
+
+    if (lib)
+      list(APPEND _CUDA_TOOLKIT_LIBS ${lib})
+    endif ()
+
+  endforeach ()
+
   set_property(TARGET cuda::toolkit PROPERTY
-    INTERFACE_LINK_LIBRARIES
-    "${CUDA_CUBLAS_LIBRARIES}" "${CUDA_LIBRARIES}" "${CUDA_CUDA_LIBRARY}"
-    "${CUB_LIBRARIES}" "${NVML_LIBRARIES}")
+    INTERFACE_LINK_LIBRARIES "${_CUDA_TOOLKIT_LIBS}")
 
   set_property(TARGET cuda::toolkit PROPERTY
     INTERFACE_COMPILE_OPTIONS $<$<COMPILE_LANGUAGE:CUDA>:-arch=sm_30>)


### PR DESCRIPTION
There's an issue where CMake (checked at v3.12) goes looking for the cuBLAS device library, but CUDA 10 doesn't seem to have this library any longer. So the value gets set to CUDA_cublas_device_LIBRARY-NOTFOUND. This just checks that every library in the list is valid before adding it to the link line. "Valid" just means that it's not a value CMake interprets as `false`.