### PR TITLE
remove compute functions from Matrix

### DIFF
--- a/include/El/core/Matrix/decl.hpp
+++ b/include/El/core/Matrix/decl.hpp
@@ -97,17 +97,6 @@ public:
     Matrix<Ring, Device::CPU> operator()(
         vector<Int> const& I, vector<Int> const& J) const;
 
-
-    // Rescaling
-    Matrix<Ring, Device::CPU> const& operator*=(Ring const& alpha);
-
-    // Addition/substraction
-    Matrix<Ring, Device::CPU> const&
-    operator+=(Matrix<Ring, Device::CPU> const& A);
-
-    Matrix<Ring, Device::CPU> const&
-    operator-=(Matrix<Ring, Device::CPU> const& A);
-
     //
     // Basic queries
     //

--- a/include/El/core/Matrix/impl_cpu.hpp
+++ b/include/El/core/Matrix/impl_cpu.hpp
@@ -219,37 +219,6 @@ Matrix<Ring, Device::CPU>::operator=(Matrix<Ring, Device::CPU>&& A)
     return *this;
 }
 
-// Rescaling
-// ---------
-template<typename Ring>
-Matrix<Ring, Device::CPU> const&
-Matrix<Ring, Device::CPU>::operator*=(Ring const& alpha)
-{
-    EL_DEBUG_CSE
-    Scale(alpha, *this);
-    return *this;
-}
-
-// Addition/subtraction
-// --------------------
-template<typename Ring>
-Matrix<Ring, Device::CPU> const&
-Matrix<Ring, Device::CPU>::operator+=(Matrix<Ring, Device::CPU> const& A)
-{
-    EL_DEBUG_CSE
-    Axpy(Ring(1), A, *this);
-    return *this;
-}
-
-template<typename Ring>
-Matrix<Ring, Device::CPU> const&
-Matrix<Ring, Device::CPU>::operator-=(Matrix<Ring, Device::CPU> const& A)
-{
-    EL_DEBUG_CSE
-    Axpy(Ring(-1), A, *this);
-    return *this;
-}
-
 // Basic queries
 // =============
 


### PR DESCRIPTION
The mathematician in me is somewhat unhappy because `+=`, anyway, assumes the operators are in the same vector space or group, which is a runtime property (and the having `+=` is a static property).

The computer scientist in me says "Prefer non-member non-friend functions." (Meyers, EffC++, 1992) (Yes, actually 1992. It's about time this started to catch on, folks!)

Both of these suggest to me that these should not be member functions. Essentially this shifts the paradigm (only slightly, because only 3 functions) to having `Matrix<T,D>` as a storage type upon which compute operations can operate.

There is no compilation issue with LBANN.