### PR TITLE
CUDA/cuBLAS error checking in release mode

### DIFF
--- a/include/El/core/imports/cublas.hpp
+++ b/include/El/core/imports/cublas.hpp
@@ -83,9 +83,21 @@ struct CublasError : std::runtime_error
             }                                                           \
         }                                                               \
     } while (0)
+#define EL_FORCE_CHECK_CUBLAS_NOSYNC(cublas_call)                       \
+    do                                                                  \
+    {                                                                   \
+        /* Make cuBLAS call and check for errors without */             \
+        /* synchronizing. */                                            \
+        const cublasStatus_t status_CHECK_CUBLAS = (cublas_call);       \
+        if (status_CHECK_CUBLAS != CUBLAS_STATUS_SUCCESS)               \
+        {                                                               \
+            cudaDeviceReset();                                          \
+            throw CublasError(status_CHECK_CUBLAS,__FILE__,__LINE__);   \
+        }
+    } while (0)
 
 #ifdef EL_RELEASE
-#define EL_CHECK_CUBLAS(cublas_call) (cublas_call)
+#define EL_CHECK_CUBLAS(cublas_call) EL_FORCE_CHECK_CUBLAS_NOSYNC(cublas_call)
 #else
 #define EL_CHECK_CUBLAS(cublas_call) EL_FORCE_CHECK_CUBLAS(cublas_call)
 #endif // #ifdef EL_RELEASE

--- a/include/El/core/imports/cuda.hpp
+++ b/include/El/core/imports/cuda.hpp
@@ -61,14 +61,13 @@ struct CudaError : std::runtime_error
 #define EL_FORCE_CHECK_CUDA_NOSYNC(cuda_call)                           \
     do                                                                  \
     {                                                                   \
-        /* Call CUDA API routine, synchronizing before and after to */  \
-        /* check for errors. */                                         \
+        /* Call CUDA API routine, and check for errors without */       \
+        /* synchronizing. */                                            \
         cudaError_t status_CHECK_CUDA = cuda_call ;                     \
         if( status_CHECK_CUDA != cudaSuccess ) {                        \
             cudaDeviceReset();                                          \
             throw CudaError(status_CHECK_CUDA,__FILE__,__LINE__,false); \
         }                                                               \
-        EL_CUDA_SYNC(false);                                            \
     } while (0)
 #define EL_LAUNCH_CUDA_KERNEL(kernel, Dg, Db, Ns, S, args)      \
     do                                                          \
@@ -92,7 +91,7 @@ struct CudaError : std::runtime_error
     while (0)
 
 #ifdef EL_RELEASE
-#define EL_CHECK_CUDA( cuda_call ) cuda_call
+#define EL_CHECK_CUDA( cuda_call ) EL_FORCE_CHECK_CUDA_NOSYNC(cuda_call)
 #define EL_CHECK_CUDA_KERNEL(kernel, Dg, Db, Ns, S, args) \
   EL_LAUNCH_CUDA_KERNEL(kernel, Dg, Db, Ns, S, args)
 #else


### PR DESCRIPTION
This checks CUDA and cuBLAS return codes without doing device synchronization in release mode.

One potential issue: We potentially throw in destructors. Compilers complain about this (`-Wterminate`). We have the same issue in debug mode.