### PR TITLE
uint8_t matrices

### DIFF
--- a/include/El/blas_like/level1/Copy.hpp
+++ b/include/El/blas_like/level1/Copy.hpp
@@ -579,6 +579,10 @@ EL_EXTERN template void Copy(
 EL_EXTERN template void Copy(
     const Matrix<cpu_half_type>& A, Matrix<cpu_half_type>& B );
 #endif // HYDROGEN_HAVE_HALF
+EL_EXTERN template void Copy(
+    const AbstractMatrix<uint8_t>& A, AbstractMatrix<uint8_t>& B );
+EL_EXTERN template void Copy(
+    const Matrix<uint8_t>& A, Matrix<uint8_t>& B );
 
 #define EL_ENABLE_DOUBLEDOUBLE
 #define EL_ENABLE_QUADDOUBLE

--- a/include/El/blas_like/level1/GetSubmatrix.hpp
+++ b/include/El/blas_like/level1/GetSubmatrix.hpp
@@ -355,6 +355,22 @@ EL_EXTERN template void GetSubmatrix(
     const vector<Int>& I, const vector<Int>& J,
     Matrix<cpu_half_type>& ASub );
 #endif /* HYDROGEN_HAVE_HALF */
+EL_EXTERN template void GetSubmatrix(
+    const Matrix<uint8_t>& A,
+    Range<Int> I, Range<Int> J,
+    Matrix<uint8_t>& ASub );
+EL_EXTERN template void GetSubmatrix(
+    const Matrix<uint8_t>& A,
+    const Range<Int> I, const vector<Int>& J,
+    Matrix<uint8_t>& ASub );
+EL_EXTERN template void GetSubmatrix(
+    const Matrix<uint8_t>& A,
+    const vector<Int>& I, const Range<Int> J,
+    Matrix<uint8_t>& ASub );
+EL_EXTERN template void GetSubmatrix(
+    const Matrix<uint8_t>& A,
+    const vector<Int>& I, const vector<Int>& J,
+    Matrix<uint8_t>& ASub );
 
 #define EL_ENABLE_DOUBLEDOUBLE
 #define EL_ENABLE_QUADDOUBLE

--- a/include/El/core.hpp
+++ b/include/El/core.hpp
@@ -127,6 +127,8 @@ template<> struct IsScalar<unsigned long long>
 { static const bool value=true; };
 template<> struct IsScalar<long long int>
 { static const bool value=true; };
+template<> struct IsScalar<unsigned char>
+{ static const bool value=true; };
 template<> struct IsScalar<float>
 { static const bool value=true; };
 template<> struct IsScalar<double>
@@ -165,6 +167,7 @@ template<> struct IsField<double>
 { static const bool value=true; };
 template<> struct IsField<long double>
 { static const bool value=true; };
+template<> struct IsField<unsigned char> : std::true_type {};
 #ifdef HYDROGEN_HAVE_HALF
 template <> struct IsField<cpu_half_type> : std::true_type {};
 #endif
@@ -207,6 +210,7 @@ template<> struct IsStdScalar<double>
 { static const bool value=true; };
 template<> struct IsStdScalar<long double>
 { static const bool value=true; };
+template<> struct IsStdScalar<unsigned char> : std::true_type {};
 #ifdef HYDROGEN_HAVE_HALF
 // This should work via ADL
 template <> struct IsStdScalar<cpu_half_type> : std::true_type {};
@@ -228,6 +232,7 @@ template<> struct IsStdField<double>
 { static const bool value=true; };
 template<> struct IsStdField<long double>
 { static const bool value=true; };
+template<> struct IsStdField<unsigned char> : std::true_type {};
 #ifdef HYDROGEN_HAVE_HALF
 template <> struct IsStdField<cpu_half_type> : std::true_type {};
 #endif

--- a/include/El/core/Element/decl.hpp
+++ b/include/El/core/Element/decl.hpp
@@ -25,6 +25,7 @@ std::string TypeName()
 
 template<> std::string TypeName<bool>();
 template<> std::string TypeName<char>();
+template<> std::string TypeName<unsigned char>();
 template<> std::string TypeName<char*>();
 template<> std::string TypeName<const char*>();
 template<> std::string TypeName<std::string>();
@@ -188,6 +189,7 @@ template<> struct IsData<Unsigned> { static const bool value=true; };
 template<> struct IsData<Int> { static const bool value=true; };
 template<> struct IsData<float> { static const bool value=true; };
 template<> struct IsData<double> { static const bool value=true; };
+template<> struct IsData<unsigned char> : std::true_type {};
 #ifdef HYDROGEN_HAVE_HALF
 template <> struct IsData<cpu_half_type> : std::true_type {};
 #endif

--- a/include/El/core/Matrix/impl_cpu.hpp
+++ b/include/El/core/Matrix/impl_cpu.hpp
@@ -635,6 +635,7 @@ int Matrix<Ring, Device::CPU>::RowAlign() const EL_NO_EXCEPT { return 0; }
 #ifdef HYDROGEN_HAVE_HALF
 PROTO(cpu_half_type)
 #endif
+PROTO(uint8_t)
 
 #include <El/macros/Instantiate.h>
 


### PR DESCRIPTION
This adds `uint8_t` as a storage type for `Matrix`. This is essentially the same as for `cpu_half_type`.