### PR TITLE
add ETI for a Copy with gpu and cpu "half" types

### DIFF
--- a/include/El/blas_like/level1/Copy.hpp
+++ b/include/El/blas_like/level1/Copy.hpp
@@ -554,6 +554,9 @@ void CopyFromNonRoot
 #ifdef HYDROGEN_GPU_USE_FP16
 EL_EXTERN template void Copy(
     const AbstractMatrix<gpu_half_type>& A, AbstractMatrix<gpu_half_type>& B );
+EL_EXTERN template void Copy(
+    const AbstractDistMatrix<gpu_half_type>& A,
+    AbstractDistMatrix<gpu_half_type>& B );
 EL_EXTERN template void Copy
 ( const Matrix<gpu_half_type,Device::GPU>& A, Matrix<gpu_half_type,Device::GPU>& B );
 EL_EXTERN template void Copy
@@ -590,6 +593,9 @@ EL_EXTERN template void CopyAsync
 #ifdef HYDROGEN_HAVE_HALF
 EL_EXTERN template void Copy(
     const AbstractMatrix<cpu_half_type>& A, AbstractMatrix<cpu_half_type>& B );
+EL_EXTERN template void Copy(
+    const AbstractDistMatrix<cpu_half_type>& A,
+    AbstractDistMatrix<cpu_half_type>& B );
 EL_EXTERN template void Copy(
     const Matrix<cpu_half_type>& A, Matrix<cpu_half_type>& B );
 #endif // HYDROGEN_HAVE_HALF

--- a/src/blas_like/level2/Gemv.cpp
+++ b/src/blas_like/level2/Gemv.cpp
@@ -353,11 +353,6 @@ template void Gemv(Orientation orientA,
   (Orientation orientation, \
     T alpha, const DistMatrix<T,MC,MR,BLOCK>& A, \
              const DistMatrix<T,MC,MR,BLOCK>& x, \
-    T beta,        DistMatrix<T,MC,MR,BLOCK>& y); \
-  template void Gemv \
-  (Orientation orientation, \
-    T alpha, const DistMatrix<T,MC,MR,BLOCK>& A, \
-             const DistMatrix<T,MC,MR,BLOCK>& x, \
                    DistMatrix<T,MC,MR,BLOCK>& y); \
   template void LocalGemv \
   (Orientation orientation, \
@@ -371,6 +366,19 @@ template void Gemv(Orientation orientA,
 #define EL_ENABLE_BIGINT
 #define EL_ENABLE_BIGFLOAT
 #define EL_ENABLE_HALF
+#include <El/macros/Instantiate.h>
+
+// Fix "explicit instantiation after explicit specialization" warnings
+#undef PROTO
+#define PROTO(T)                                        \
+    template void Gemv                                  \
+    (Orientation orientation,                           \
+     T alpha, const DistMatrix<T,MC,MR,BLOCK>& A,       \
+     const DistMatrix<T,MC,MR,BLOCK>& x,                \
+     T beta,        DistMatrix<T,MC,MR,BLOCK>& y);
+
+#define EL_NO_INT_PROTO
+#undef EL_ENABLE_QUAD
 #include <El/macros/Instantiate.h>
 
 } // namespace El


### PR DESCRIPTION
When compiling with half-precision support, I got a linker error saying these symbols were missing. I don't anymore.