### PR TITLE
Bump aluminum version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -393,13 +393,13 @@ endif (Hydrogen_ENABLE_CUDA)
 set(HYDROGEN_HAVE_GPU ${HYDROGEN_HAVE_CUDA})
 
 if (Hydrogen_ENABLE_ALUMINUM)
-  find_package(Aluminum 0.2.0 NO_MODULE QUIET
+  find_package(Aluminum 0.3.0 NO_MODULE
     HINTS ${Aluminum_DIR} ${ALUMINUM_DIR} ${AL_DIR}
     $ENV{Aluminum_DIR} $ENV{ALUMINUM_DIR} $ENV{AL_DIR}
     PATH_SUFFIXES lib64/cmake/aluminum lib/cmake/aluminum
     NO_DEFAULT_PATH)
   if (NOT Aluminum_FOUND)
-    find_package(Aluminum 0.2.0 NO_MODULE QUIET)
+    find_package(Aluminum 0.3.0 NO_MODULE)
   endif ()
 
   if (Aluminum_FOUND)

--- a/include/El/blas_like/level1/Copy.hpp
+++ b/include/El/blas_like/level1/Copy.hpp
@@ -554,6 +554,9 @@ void CopyFromNonRoot
 #ifdef HYDROGEN_GPU_USE_FP16
 EL_EXTERN template void Copy(
     const AbstractMatrix<gpu_half_type>& A, AbstractMatrix<gpu_half_type>& B );
+EL_EXTERN template void Copy(
+    const AbstractDistMatrix<gpu_half_type>& A,
+    AbstractDistMatrix<gpu_half_type>& B );
 EL_EXTERN template void Copy
 ( const Matrix<gpu_half_type,Device::GPU>& A, Matrix<gpu_half_type,Device::GPU>& B );
 EL_EXTERN template void Copy
@@ -590,6 +593,9 @@ EL_EXTERN template void CopyAsync
 #ifdef HYDROGEN_HAVE_HALF
 EL_EXTERN template void Copy(
     const AbstractMatrix<cpu_half_type>& A, AbstractMatrix<cpu_half_type>& B );
+EL_EXTERN template void Copy(
+    const AbstractDistMatrix<cpu_half_type>& A,
+    AbstractDistMatrix<cpu_half_type>& B );
 EL_EXTERN template void Copy(
     const Matrix<cpu_half_type>& A, Matrix<cpu_half_type>& B );
 #endif // HYDROGEN_HAVE_HALF


### PR DESCRIPTION
Compiled fine against current `llnl/aluminum:master` with all backends. Enabled all bells and whistles in Hydrogen and things were fine.