### PR TITLE
Expose a variety of tuning knobs for CUB's memory pool

### DIFF
--- a/include/hydrogen/device/gpu/cuda/CUB.hpp
+++ b/include/hydrogen/device/gpu/cuda/CUB.hpp
@@ -9,7 +9,24 @@ namespace hydrogen
 namespace cub
 {
 
-    /** Get singleton instance of CUB memory pool. */
+    /** @brief Get singleton instance of CUB memory pool.
+     *
+     *  A new memory pool is constructed if one doesn't exist
+     *  already. The following environment variables are used to
+     *  control the construction of the memory pool:
+     *
+     *    - H_CUB_BIN_GROWTH: The growth factor. (Default: 2)
+     *    - H_CUB_MIN_BIN: The minimum bin. (Default: 1)
+     *    - H_CUB_MAX_BIN: The maximum bin. (Default: no max bin)
+     *    - H_CUB_MAX_CACHED_SIZE: The maximum aggregate cached bytes
+     *      per device. (Default: No maximum)
+     *    - H_CUB_DEBUG: If nonzero, allow CUB to print debugging output.
+     *
+     *  Note that if debugging output is turned on, there is no
+     *  synchronization across processes. Users should take care to
+     *  redirect output on a per-rank basis, either through the
+     *  features exposed by their MPI launcher or by some other means.
+     */
     ::cub::CachingDeviceAllocator& MemoryPool();
     /** Destroy singleton instance of CUB memory pool. */
     void DestroyMemoryPool();

--- a/src/core/imports/cub.cpp
+++ b/src/core/imports/cub.cpp
@@ -4,6 +4,48 @@
 
 namespace
 {
+
+unsigned int get_env_uint(char const* env_var_name,
+                          unsigned int default_value = 0U) noexcept
+{
+    char const* env = std::getenv(env_var_name);
+    return (env
+            ? static_cast<unsigned>(std::stoi(env))
+            : default_value);
+}
+
+unsigned int get_bin_growth() noexcept
+{
+    return get_env_uint("H_CUB_BIN_GROWTH", 2U);
+}
+
+unsigned int get_min_bin() noexcept
+{
+    return get_env_uint("H_CUB_MIN_BIN", 1U);
+}
+
+unsigned int get_max_bin() noexcept
+{
+    return get_env_uint("H_CUB_MAX_BIN",
+                        ::cub::CachingDeviceAllocator::INVALID_BIN);
+}
+
+size_t get_max_cached_size() noexcept
+{
+    char const* env = std::getenv("H_CUB_MAX_CACHED_SIZE");
+    return (env
+            ? static_cast<size_t>(std::stoul(env))
+            : ::cub::CachingDeviceAllocator::INVALID_SIZE);
+}
+
+bool get_debug() noexcept
+{
+    char const* env = std::getenv("H_CUB_DEBUG");
+    return (env
+            ? static_cast<bool>(std::stoi(env))
+            : false);
+}
+
 /** Singleton instance of CUB memory pool. */
 std::unique_ptr<::cub::CachingDeviceAllocator> memoryPool_;
 } // namespace <anon>
@@ -16,7 +58,14 @@ namespace cub
 ::cub::CachingDeviceAllocator& MemoryPool()
 {
     if (!memoryPool_)
-        memoryPool_.reset(new ::cub::CachingDeviceAllocator(2u));
+        memoryPool_.reset(
+            new ::cub::CachingDeviceAllocator(
+                get_bin_growth(),
+                get_min_bin(),
+                get_max_bin(),
+                get_max_cached_size(),
+                /*skip_cleanup=*/false,
+                get_debug()));
     return *memoryPool_;
 }
 


### PR DESCRIPTION
These are "expert features". Environment variables allow a simple, flexible interface without needing to change downstreams at all. The default values match the CUB default arguments and are used if the environment variables are not found at runtime.