### PR TITLE
(Re)Enable Cholesky factorization of matrices

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -373,7 +373,8 @@ if (Hydrogen_ENABLE_CUDA)
       add_library(cuda::toolkit INTERFACE IMPORTED)
 
       foreach (lib IN LISTS CUDA_CUBLAS_LIBRARIES CUDA_LIBRARIES
-          CUDA_CUDA_LIBRARY CUB_LIBRARIES NVML_LIBRARIES)
+          CUDA_CUDA_LIBRARY CUB_LIBRARIES NVML_LIBRARIES
+          CUDA_cusolver_LIBRARY)
 
         if (lib)
           list(APPEND _CUDA_TOOLKIT_LIBS ${lib})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -419,7 +419,8 @@ if (Hydrogen_ENABLE_ROCM)
 
   if (HIP_FOUND)
     set(CMAKE_CXX_EXTENSIONS FALSE)
-    find_package(ROCBLAS REQUIRED)
+    find_package(rocblas CONFIG REQUIRED)
+    find_package(rocsolver CONFIG REQUIRED)
     set(HYDROGEN_HAVE_ROCM TRUE)
     message(STATUS "Found ROCm/HIP toolchain. Using HIP/ROCm.")
   else ()
@@ -566,7 +567,6 @@ target_link_libraries(
   ${HALF_LIBRARIES}
   ${VTUNE_LIBRARIES}
   ${NVTX_LIBRARIES}
-  ${ROCBLAS_LIBRARIES}
   $<TARGET_NAME_IF_EXISTS:OpenMP::OpenMP_CXX>
   $<TARGET_NAME_IF_EXISTS:MPI::MPI_CXX>
   $<TARGET_NAME_IF_EXISTS:LAPACK::lapack>
@@ -574,6 +574,8 @@ target_link_libraries(
   $<TARGET_NAME_IF_EXISTS:cuda::toolkit>
   $<TARGET_NAME_IF_EXISTS:hip::rocprim_hip>
   $<TARGET_NAME_IF_EXISTS:hip::hipcub>
+  $<TARGET_NAME_IF_EXISTS:roc::rocblas>
+  $<TARGET_NAME_IF_EXISTS:roc::rocsolver>
   )
 
 # Add the CXX library to "Hydrogen"

--- a/include/El/blas_like/level3.hpp
+++ b/include/El/blas_like/level3.hpp
@@ -105,23 +105,26 @@ void Hemm
 // Herk
 // ====
 template<typename T>
-void Herk
-( UpperOrLower uplo, Orientation orientation,
-  Base<T> alpha, const Matrix<T>& A, Base<T> beta, Matrix<T>& C );
+void Herk(
+    UpperOrLower uplo, Orientation orientation,
+    Base<T> alpha, const AbstractMatrix<T>& A,
+    Base<T> beta, AbstractMatrix<T>& C);
 template<typename T>
-void Herk
-( UpperOrLower uplo, Orientation orientation,
-  Base<T> alpha, const Matrix<T>& A, Matrix<T>& C );
+void Herk(
+    UpperOrLower uplo, Orientation orientation,
+    Base<T> alpha, const AbstractMatrix<T>& A,
+    AbstractMatrix<T>& C);
 
 template<typename T>
-void Herk
-( UpperOrLower uplo, Orientation orientation,
-  Base<T> alpha, const AbstractDistMatrix<T>& A,
-  Base<T> beta,        AbstractDistMatrix<T>& C );
+void Herk(
+    UpperOrLower uplo, Orientation orientation,
+    Base<T> alpha, const AbstractDistMatrix<T>& A,
+    Base<T> beta,        AbstractDistMatrix<T>& C);
 template<typename T>
-void Herk
-( UpperOrLower uplo, Orientation orientation,
-  Base<T> alpha, const AbstractDistMatrix<T>& A, AbstractDistMatrix<T>& C );
+void Herk(
+    UpperOrLower uplo, Orientation orientation,
+    Base<T> alpha, const AbstractDistMatrix<T>& A,
+    AbstractDistMatrix<T>& C);
 
 // Her2k
 // =====
@@ -291,12 +294,14 @@ void LocalAccumulateRU
 template<typename T>
 void Syrk
 ( UpperOrLower uplo, Orientation orientation,
-  T alpha, const Matrix<T>& A, T beta, Matrix<T>& C,
+  T alpha, const AbstractMatrix<T>& A,
+  T beta, AbstractMatrix<T>& C,
   bool conjugate=false );
 template<typename T>
 void Syrk
 ( UpperOrLower uplo, Orientation orientation,
-  T alpha, const Matrix<T>& A, Matrix<T>& C,
+  T alpha, const AbstractMatrix<T>& A,
+  AbstractMatrix<T>& C,
   bool conjugate=false );
 
 template<typename T>

--- a/include/El/blas_like/level3.hpp
+++ b/include/El/blas_like/level3.hpp
@@ -402,19 +402,20 @@ enum TrsmAlgorithm {
 using namespace TrsmAlgorithmNS;
 
 template<typename F>
-void Trsm
-( LeftOrRight side, UpperOrLower uplo,
-  Orientation orientation, UnitOrNonUnit diag,
-  F alpha, const Matrix<F>& A, Matrix<F>& B,
-  bool checkIfSingular=false );
+void Trsm(
+    LeftOrRight side, UpperOrLower uplo,
+    Orientation orientation, UnitOrNonUnit diag,
+    F alpha, AbstractMatrix<F> const& A, AbstractMatrix<F>& B,
+    bool checkIfSingular=false);
 template<typename F>
-void Trsm
-( LeftOrRight side, UpperOrLower uplo,
-  Orientation orientation, UnitOrNonUnit diag,
-  F alpha,
-  const AbstractDistMatrix<F>& A,
-        AbstractDistMatrix<F>& B,
-  bool checkIfSingular=false, TrsmAlgorithm alg=TRSM_DEFAULT );
+void Trsm(
+    LeftOrRight side, UpperOrLower uplo,
+    Orientation orientation, UnitOrNonUnit diag,
+    F alpha,
+    AbstractDistMatrix<F> const& A,
+    AbstractDistMatrix<F>& B,
+    bool checkIfSingular=false,
+    TrsmAlgorithm alg=TRSM_DEFAULT);
 
 template<typename F>
 void LocalTrsm

--- a/include/El/core/types.hpp
+++ b/include/El/core/types.hpp
@@ -422,6 +422,17 @@ enum LeftOrRight
 };
 char LeftOrRightToChar( LeftOrRight side );
 LeftOrRight CharToLeftOrRight( char c );
+inline SideMode LeftOrRightToSideMode(LeftOrRight side)
+{
+    switch (side)
+    {
+    case LEFT:
+        return SideMode::LEFT;
+    case RIGHT:
+        return SideMode::RIGHT;
+    }
+    return SideMode::LEFT;
+}
 }
 using namespace LeftOrRightNS;
 
@@ -482,6 +493,17 @@ enum UnitOrNonUnit
 };
 char UnitOrNonUnitToChar( UnitOrNonUnit diag );
 UnitOrNonUnit CharToUnitOrNonUnit( char c );
+inline DiagType UnitOrNonUnitToDiagType(UnitOrNonUnit diag)
+{
+    switch (diag)
+    {
+    case NON_UNIT:
+        return DiagType::NON_UNIT;
+    case UNIT:
+        return DiagType::UNIT;
+    }
+    return DiagType::UNIT;
+}
 }
 using namespace UnitOrNonUnitNS;
 
@@ -493,6 +515,17 @@ enum UpperOrLower
 };
 char UpperOrLowerToChar( UpperOrLower uplo );
 UpperOrLower CharToUpperOrLower( char c );
+inline FillMode UpperOrLowerToFillMode(UpperOrLower uplo)
+{
+    switch (uplo)
+    {
+    case LOWER:
+        return FillMode::LOWER_TRIANGLE;
+    case UPPER:
+        return FillMode::UPPER_TRIANGLE;
+    }
+    return FillMode::FULL;
+}
 }
 using namespace UpperOrLowerNS;
 

--- a/include/El/lapack_like/factor.hpp
+++ b/include/El/lapack_like/factor.hpp
@@ -19,7 +19,7 @@ namespace El {
 // Cholesky
 // ========
 template<typename Field>
-void Cholesky( UpperOrLower uplo, Matrix<Field>& A );
+void Cholesky( UpperOrLower uplo, AbstractMatrix<Field>& A );
 template<typename Field>
 void Cholesky
 ( UpperOrLower uplo, AbstractDistMatrix<Field>& A, bool scalapack=false );

--- a/include/hydrogen/blas/BLAS_Common.hpp
+++ b/include/hydrogen/blas/BLAS_Common.hpp
@@ -21,8 +21,10 @@ enum class BLAS_Op
     GEMM,
     GEMMSTRIDEDBATCHED,
     GEMV,
+    HERK,
     NRM2,
     SCAL,
+    SYRK,
     /** @brief Axpy for 2D data with leading dimension */
     AXPY2D,
     /** @brief Copy for 2D data with leading dimension */
@@ -32,6 +34,42 @@ enum class BLAS_Op
     /** @brief In-place scale for 2D data with leading dimension */
     SCALE2D,
 };
+
+/** @brief Describes the fill mode for BLAS. */
+enum class FillMode
+{
+    UPPER_TRIANGLE,
+    LOWER_TRIANGLE,
+    FULL,
+};
+
+inline char FillModeToChar(FillMode mode)
+{
+    switch (mode)
+    {
+    case FillMode::UPPER_TRIANGLE:
+        return 'U';
+    case FillMode::LOWER_TRIANGLE:
+        return 'L';
+    case FillMode::FULL:
+        return 'F';
+    }
+    return 'F';
+}
+
+inline FillMode CharToFillMode(char c)
+{
+    switch (c)
+    {
+    case 'U':
+        return FillMode::UPPER_TRIANGLE;
+    case 'L':
+        return FillMode::LOWER_TRIANGLE;
+    case 'F':
+        return FillMode::FULL;
+    }
+    throw std::logic_error("Bad char");
+}
 
 /** @brief Describes transpose operations for BLAS. */
 enum class TransposeMode

--- a/include/hydrogen/blas/BLAS_Common.hpp
+++ b/include/hydrogen/blas/BLAS_Common.hpp
@@ -25,6 +25,7 @@ enum class BLAS_Op
     NRM2,
     SCAL,
     SYRK,
+    TRSM,
     /** @brief Axpy for 2D data with leading dimension */
     AXPY2D,
     /** @brief Copy for 2D data with leading dimension */
@@ -113,6 +114,12 @@ enum class SideMode
 {
     LEFT,
     RIGHT,
+};
+
+enum class DiagType
+{
+    UNIT,
+    NON_UNIT,
 };
 
 /** @brief Describes where pointers point. */

--- a/include/hydrogen/blas/BLAS_Common.hpp
+++ b/include/hydrogen/blas/BLAS_Common.hpp
@@ -34,7 +34,12 @@ enum class BLAS_Op
     COPY2DSTRIDED,
     /** @brief In-place scale for 2D data with leading dimension */
     SCALE2D,
-};
+}; // enum class BLAS_Op
+
+enum class LAPACK_Op
+{
+    POTRF,
+}; // enum class LAPACK_Op
 
 /** @brief Describes the fill mode for BLAS. */
 enum class FillMode

--- a/include/hydrogen/blas/GPU_BLAS_decl.hpp
+++ b/include/hydrogen/blas/GPU_BLAS_decl.hpp
@@ -21,6 +21,25 @@
 
 namespace hydrogen
 {
+namespace details
+{
+template <typename T>
+struct BaseT
+{
+    using type = T;
+};
+
+// Ehhhhh this is certainly not fool-proof... But I don't want to
+// include all the El::Complex stuff here.
+template <template <typename> class AugmentedT, typename T>
+struct BaseT<AugmentedT<T>>
+{
+    using type = T;
+};
+}// namespace details
+
+template <typename T>
+using TmpBase = typename details::BaseT<T>::type;
 
 /** @namespace gpu_blas
  *  @brief A collection of BLAS routines that are exposed for GPUs
@@ -391,6 +410,32 @@ void Gemv(
 ///@}
 /** @name BLAS-3 Routines */
 ///@{
+
+/** @brief Hermitian rank-K update of matrices in GPU memory.
+ *  @todo Finish documentation.
+ */
+template <typename T, typename SizeT>
+void Herk(
+    FillMode uplo, TransposeMode trans,
+    SizeT n, SizeT k,
+    TmpBase<T> const& alpha,
+    T const* A, SizeT lda,
+    TmpBase<T> const& beta,
+    T* C, SizeT ldc,
+    SyncInfo<Device::GPU> const& syncinfo);
+
+/** @brief Symmetric rank-K update of matrices in GPU memory.
+ *  @todo Finish documentation.
+ */
+template <typename T, typename SizeT>
+void Syrk(
+    FillMode uplo, TransposeMode trans,
+    SizeT n, SizeT k,
+    T const& alpha,
+    T const* A, SizeT lda,
+    T const& beta,
+    T* C, SizeT ldc,
+    SyncInfo<Device::GPU> const& syncinfo);
 
 /** @brief Matrix-matrix product in GPU memory.
  *

--- a/include/hydrogen/blas/GPU_BLAS_decl.hpp
+++ b/include/hydrogen/blas/GPU_BLAS_decl.hpp
@@ -584,5 +584,53 @@ void Dgmm(SideMode side,
 ///@}
 
 }// namespace gpu_blas
+
+namespace gpu_lapack
+{
+
+/** @brief Compute the Cholesky factorization of A.
+ *
+ *  This routine will allocate the properly-sized workspace and info
+ *  parameter, using the caching allocators if available.
+ *
+ *  @note The `info` parameter to the underlying library will only be
+ *        checked in Debug builds.
+ */
+template <typename T, typename SizeT>
+void CholeskyFactorize(FillMode uplo,
+                       SizeT n,
+                       T* A, SizeT lda,
+                       SyncInfo<Device::GPU> const& si);
+
+/** @brief Compute the Cholesky factorization of A with a user-provided
+ *         workspace.
+ *
+ *  This routine will allocate the info argument.
+ *
+ *  @note The `info` parameter to the underlying library will only be
+ *        checked in Debug builds.
+ *  @todo Improve the error reporting.
+ */
+template <typename T, typename SizeT>
+void CholeskyFactorize(FillMode uplo,
+                       SizeT n,
+                       T* A, SizeT lda,
+                       T* workspace, SizeT workspace_size,
+                       SyncInfo<Device::GPU> const& si);
+
+/** @brief Compute the Cholesky factorization of A with a user-provided
+ *         workspace and info parameter.
+ *
+ *  @note The `info` parameter will not be checked by this routine.
+ */
+template <typename T, typename SizeT, typename InfoT>
+void CholeskyFactorize(FillMode uplo,
+                       SizeT n,
+                       T* A, SizeT lda,
+                       T* workspace, SizeT workspace_size,
+                       InfoT* info,
+                       SyncInfo<Device::GPU> const& si);
+
+}// namespace gpu_lapack
 }// namespace hydrogen
 #endif // HYDROGEN_GPU_BLAS_DECL_HPP_

--- a/include/hydrogen/blas/GPU_BLAS_decl.hpp
+++ b/include/hydrogen/blas/GPU_BLAS_decl.hpp
@@ -437,6 +437,19 @@ void Syrk(
     T* C, SizeT ldc,
     SyncInfo<Device::GPU> const& syncinfo);
 
+/** @brief Triangular matrix solve.
+ *  @todo Finish documentation.
+ */
+template <typename T, typename SizeT>
+void Trsm(
+    SideMode side, FillMode uplo,
+    TransposeMode trans, DiagType diag,
+    SizeT m, SizeT n,
+    T const& alpha,
+    T const* A, SizeT lda,
+    T* B, SizeT ldb,
+    SyncInfo<Device::GPU> const& syncinfo);
+
 /** @brief Matrix-matrix product in GPU memory.
  *
  *  Perform a scaled matrix-matrix product:

--- a/include/hydrogen/blas/GPU_BLAS_impl.hpp
+++ b/include/hydrogen/blas/GPU_BLAS_impl.hpp
@@ -332,7 +332,7 @@ void SyrkImpl(
 }
 
 template <typename T, typename SizeT,
-          typename=EnableWhen<IsSupportedType<T, BLAS_Op::SYRK>>>
+          typename=EnableWhen<IsSupportedType<T, BLAS_Op::TRSM>>>
 void TrsmImpl(
     SideMode side, FillMode uplo,
     TransposeMode trans, DiagType diag,
@@ -655,7 +655,7 @@ void SyrkImpl(
 }
 
 template <typename T, typename SizeT,
-          typename=EnableUnless<IsSupportedType<T, BLAS_Op::SYRK>>,
+          typename=EnableUnless<IsSupportedType<T, BLAS_Op::TRSM>>,
           typename=void>
 void TrsmImpl(
     SideMode const, FillMode const,
@@ -969,7 +969,7 @@ void CholeskyFactorizeImpl(FillMode uplo,
     Synchronize(si);
     if (host_info > gpu_blas_impl::InfoT(0))
         throw std::runtime_error("Cholesky: Matrix not HPD.");
-    else if (host_inf < gpu::blas_impl::InfoT(0))
+    else if (host_info < gpu::blas_impl::InfoT(0))
         throw std::runtime_error("Cholesky: A parameter is bad.");
 #endif // EL_RELEASE
 }

--- a/include/hydrogen/blas/GPU_BLAS_impl.hpp
+++ b/include/hydrogen/blas/GPU_BLAS_impl.hpp
@@ -276,6 +276,7 @@ void GemvImpl(
         reinterpret_cast<NTP>(y), ToSizeT(incy));
 }
 
+
 template <typename T, typename SizeT,
           typename=EnableWhen<IsSupportedType<T, BLAS_Op::HERK>>>
 void HerkImpl(

--- a/include/hydrogen/blas/GPU_BLAS_impl.hpp
+++ b/include/hydrogen/blas/GPU_BLAS_impl.hpp
@@ -43,8 +43,10 @@ namespace gpu_lapack_impl = hydrogen::cusolver;
 
 #define GPU_BLAS_USE_ROCBLAS
 #include <hydrogen/device/gpu/rocm/rocBLAS.hpp>
+#include <hydrogen/device/gpu/rocm/rocSOLVER.hpp>
 
 namespace gpu_blas_impl = hydrogen::rocblas;
+namespace gpu_lapack_impl = hydrogen::rocsolver;
 
 #else
 #pragma GCC error "LOGIC ERROR: No GPU programming model enabled."

--- a/include/hydrogen/device/gpu/cuda/cuBLASMeta.hpp
+++ b/include/hydrogen/device/gpu/cuda/cuBLASMeta.hpp
@@ -93,6 +93,12 @@ struct IsSupportedType_Base<cuComplex, op> : std::true_type {};
 template <BLAS_Op op>
 struct IsSupportedType_Base<cuDoubleComplex, op> : std::true_type {};
 
+// I could clean this up if the need arises. "Real herk" is "syrk".
+template <>
+struct IsSupportedType_Base<float, BLAS_Op::HERK> : std::false_type {};
+template <>
+struct IsSupportedType_Base<double, BLAS_Op::HERK> : std::false_type {};
+
 // No need to further test CUDA because this file isn't included if
 // either we don't have GPUs at all or we don't have CUDA support.
 #ifdef HYDROGEN_GPU_USE_FP16

--- a/include/hydrogen/device/gpu/cuda/cuBLASMeta.hpp
+++ b/include/hydrogen/device/gpu/cuda/cuBLASMeta.hpp
@@ -93,12 +93,6 @@ struct IsSupportedType_Base<cuComplex, op> : std::true_type {};
 template <BLAS_Op op>
 struct IsSupportedType_Base<cuDoubleComplex, op> : std::true_type {};
 
-// I could clean this up if the need arises. "Real herk" is "syrk".
-template <>
-struct IsSupportedType_Base<float, BLAS_Op::HERK> : std::false_type {};
-template <>
-struct IsSupportedType_Base<double, BLAS_Op::HERK> : std::false_type {};
-
 // No need to further test CUDA because this file isn't included if
 // either we don't have GPUs at all or we don't have CUDA support.
 #ifdef HYDROGEN_GPU_USE_FP16

--- a/include/hydrogen/device/gpu/cuda/cuBLASUtil.hpp
+++ b/include/hydrogen/device/gpu/cuda/cuBLASUtil.hpp
@@ -81,6 +81,19 @@ ToNativeFillMode(FillMode const& uplo) noexcept
     return CUBLAS_FILL_MODE_FULL;
 }
 
+inline cublasDiagType_t
+ToNativeDiagType(DiagType const& diag) noexcept
+{
+    switch (diag)
+    {
+    case DiagType::UNIT:
+        return CUBLAS_DIAG_UNIT;
+    case DiagType::NON_UNIT:
+        return CUBLAS_DIAG_NON_UNIT;
+    }
+    return CUBLAS_DIAG_UNIT;
+}
+
 }// namespace cublas
 }// namespace hydrogen
 #endif // HYDROGEN_DEVICE_GPU_CUDA_CUBLASUTIL_HPP_

--- a/include/hydrogen/device/gpu/cuda/cuBLASUtil.hpp
+++ b/include/hydrogen/device/gpu/cuda/cuBLASUtil.hpp
@@ -66,6 +66,21 @@ ToNativeSideMode(SideMode const& side) noexcept
     return CUBLAS_SIDE_RIGHT;
 }
 
+inline cublasFillMode_t
+ToNativeFillMode(FillMode const& uplo) noexcept
+{
+    switch (uplo)
+    {
+    case FillMode::UPPER_TRIANGLE:
+        return CUBLAS_FILL_MODE_UPPER;
+    case FillMode::LOWER_TRIANGLE:
+        return CUBLAS_FILL_MODE_LOWER;
+    case FillMode::FULL:
+        return CUBLAS_FILL_MODE_FULL;
+    }
+    return CUBLAS_FILL_MODE_FULL;
+}
+
 }// namespace cublas
 }// namespace hydrogen
 #endif // HYDROGEN_DEVICE_GPU_CUDA_CUBLASUTIL_HPP_

--- a/include/hydrogen/device/gpu/cuda/cuBLAS_API.hpp
+++ b/include/hydrogen/device/gpu/cuda/cuBLAS_API.hpp
@@ -160,6 +160,8 @@ ADD_GEMV_DECL(cuDoubleComplex);
         long long int strideC,                          \
         int batchCount)
 
+ADD_HERK_DECL(float, float);
+ADD_HERK_DECL(double, double);
 ADD_HERK_DECL(cuComplex, float);
 ADD_HERK_DECL(cuDoubleComplex, double);
 

--- a/include/hydrogen/device/gpu/cuda/cuBLAS_API.hpp
+++ b/include/hydrogen/device/gpu/cuda/cuBLAS_API.hpp
@@ -102,6 +102,26 @@ ADD_GEMV_DECL(cuDoubleComplex);
 /** @name BLAS-3 Routines */
 ///@{
 
+#define ADD_HERK_DECL(ScalarType, BaseScalarType)               \
+    void Herk(                                                  \
+        cublasHandle_t handle,                                  \
+        cublasFillMode_t uplo, cublasOperation_t trans,         \
+        int n, int k,                                           \
+        BaseScalarType const& alpha,                            \
+        ScalarType const* A, int lda,                           \
+        BaseScalarType const& beta,                             \
+        ScalarType * C, int ldc)
+
+#define ADD_SYRK_DECL(ScalarType)                       \
+    void Syrk(                                          \
+        cublasHandle_t handle,                          \
+        cublasFillMode_t uplo, cublasOperation_t trans, \
+        int n, int k,                                   \
+        ScalarType const& alpha,                        \
+        ScalarType const* A, int lda,                   \
+        ScalarType const& beta,                         \
+        ScalarType* C, int ldc)
+
 #define ADD_GEMM_DECL(ScalarType)               \
     void Gemm(                                  \
         cublasHandle_t handle,                  \
@@ -129,6 +149,14 @@ ADD_GEMV_DECL(cuDoubleComplex);
         ScalarType* C, int ldc,                         \
         long long int strideC,                          \
         int batchCount)
+
+ADD_HERK_DECL(cuComplex, float);
+ADD_HERK_DECL(cuDoubleComplex, double);
+
+ADD_SYRK_DECL(float);
+ADD_SYRK_DECL(double);
+ADD_SYRK_DECL(cuComplex);
+ADD_SYRK_DECL(cuDoubleComplex);
 
 #ifdef HYDROGEN_GPU_USE_FP16
 ADD_GEMM_DECL(__half);

--- a/include/hydrogen/device/gpu/cuda/cuBLAS_API.hpp
+++ b/include/hydrogen/device/gpu/cuda/cuBLAS_API.hpp
@@ -122,6 +122,16 @@ ADD_GEMV_DECL(cuDoubleComplex);
         ScalarType const& beta,                         \
         ScalarType* C, int ldc)
 
+#define ADD_TRSM_DECL(ScalarType)                             \
+    void Trsm(                                                \
+        cublasHandle_t handle,                                \
+        cublasSideMode_t side, cublasFillMode_t uplo,         \
+        cublasOperation_t trans, cublasDiagType_t diag,       \
+        int m, int n,                                         \
+        ScalarType const& alpha,                              \
+        ScalarType const* A, int lda,                         \
+        ScalarType* B, int ldb)
+
 #define ADD_GEMM_DECL(ScalarType)               \
     void Gemm(                                  \
         cublasHandle_t handle,                  \
@@ -157,6 +167,11 @@ ADD_SYRK_DECL(float);
 ADD_SYRK_DECL(double);
 ADD_SYRK_DECL(cuComplex);
 ADD_SYRK_DECL(cuDoubleComplex);
+
+ADD_TRSM_DECL(float);
+ADD_TRSM_DECL(double);
+ADD_TRSM_DECL(cuComplex);
+ADD_TRSM_DECL(cuDoubleComplex);
 
 #ifdef HYDROGEN_GPU_USE_FP16
 ADD_GEMM_DECL(__half);

--- a/include/hydrogen/device/gpu/cuda/cuSOLVER.hpp
+++ b/include/hydrogen/device/gpu/cuda/cuSOLVER.hpp
@@ -1,0 +1,12 @@
+#ifndef HYDROGEN_DEVICE_GPU_CUDA_CUSOLVER_HPP_
+#define HYDROGEN_DEVICE_GPU_CUDA_CUSOLVER_HPP_
+
+#include "cuSOLVERError.hpp"
+#include "cuSOLVERManagement.hpp"
+#include "cuSOLVERMeta.hpp"
+#include "cuSOLVERUtil.hpp"
+
+// The API wrapper declarations
+#include "cuSOLVER_API.hpp"
+
+#endif // HYDROGEN_DEVICE_GPU_CUDA_CUSOLVER_HPP_

--- a/include/hydrogen/device/gpu/cuda/cuSOLVERError.hpp
+++ b/include/hydrogen/device/gpu/cuda/cuSOLVERError.hpp
@@ -1,0 +1,48 @@
+#ifndef HYDROGEN_DEVICE_GPU_CUDA_CUSOLVERERROR_HPP_
+#define HYDROGEN_DEVICE_GPU_CUDA_CUSOLVERERROR_HPP_
+
+#include <El/hydrogen_config.h>
+
+#include <hydrogen/Error.hpp>
+#include <hydrogen/device/gpu/GPUError.hpp>
+
+#include <cusolverDn.h>
+
+// Helper error-checking macro.
+#define H_CHECK_CUSOLVER(cmd)                                           \
+    do                                                                  \
+    {                                                                   \
+        H_SYNC_CUDA();                                                  \
+        auto h_check_cusolver_err_code__ = cmd;                           \
+        H_ASSERT(h_check_cusolver_err_code__ == CUSOLVER_STATUS_SUCCESS,  \
+                 cuSOLVERError,                                         \
+                 (cudaDeviceReset(),                                    \
+                  cusolver::BuildcuSOLVERErrorMessage(                    \
+                      #cmd,                                             \
+                      h_check_cusolver_err_code__)));                     \
+        H_SYNC_CUDA();                                                  \
+    } while (false)
+
+namespace hydrogen
+{
+
+/** @class cuSOLVERError
+ *  @brief Exception representing errors detected by cuSOLVER library.
+ */
+H_ADD_BASIC_EXCEPTION_CLASS(cuSOLVERError,GPUError);
+
+namespace cusolver
+{
+
+/** @brief Write an error message describing the error detected in CUDA.
+ *  @param[in] cmd The expression that raised the error.
+ *  @param[in] error_code The error code reported by CUDA.
+ *  @returns A string describing the error.
+ */
+std::string BuildcuSOLVERErrorMessage(
+    std::string const& cmd, cusolverStatus_t error_code);
+
+}// namespace cusolver
+
+}// namespace hydrogen
+#endif // HYDROGEN_DEVICE_GPU_CUDA_CUSOLVERERROR_HPP_

--- a/include/hydrogen/device/gpu/cuda/cuSOLVERManagement.hpp
+++ b/include/hydrogen/device/gpu/cuda/cuSOLVERManagement.hpp
@@ -43,8 +43,8 @@ void FinalizeDense();
 
 /** @brief Replace the default cuSolverDn library handle.
  *
- *  This will destroy the current default cuBLAS library handle and
- *  assume control of the input handle. The cuBLAS library must be
+ *  This will destroy the current default cuSOLVER library handle and
+ *  assume control of the input handle. The cuSOLVER library must be
  *  initialized in order to call this function.
  *
  *  \param[in] handle The new library handle. Hydrogen will take

--- a/include/hydrogen/device/gpu/cuda/cuSOLVERManagement.hpp
+++ b/include/hydrogen/device/gpu/cuda/cuSOLVERManagement.hpp
@@ -1,0 +1,78 @@
+#ifndef HYDROGEN_DEVICE_GPU_CUDA_CUSOLVERMANAGEMENT_HPP_
+#define HYDROGEN_DEVICE_GPU_CUDA_CUSOLVERMANAGEMENT_HPP_
+
+#include <El/hydrogen_config.h>
+
+#include "cuSOLVERError.hpp"
+
+#include <hydrogen/Device.hpp>
+#include <hydrogen/SyncInfo.hpp>
+
+#include <cusolverDn.h>
+
+namespace hydrogen
+{
+
+namespace cusolver
+{
+
+/** @name cuSOLVER management functions. */
+///@{
+
+/** @brief Initialize cuSOLVER's dense interface.
+ *
+ *  Creates the default library instance for cuSolverDN.
+ *
+ *  @note This must be called after `MPI_Init` is called with
+ *  MVAPICH2-GDR.
+ *
+ *  \param[in] handle The handle to use for cuSolverDN. If null, a new
+ *                    handle will be created. If not null, it is
+ *                    assumed that the handle has been created with a
+ *                    user-side call to cusolverDnCreate().
+ */
+void InitializeDense(cusolverDnHandle_t handle=nullptr);
+
+/** @brief Finalize the cuSolverDn library.
+ *
+ *  Destroys the default library handle.
+ *
+ *  \throws cuSOLVERError If the cuSOLVER library detects any errors.
+ */
+void FinalizeDense();
+
+/** @brief Replace the default cuSolverDn library handle.
+ *
+ *  This will destroy the current default cuBLAS library handle and
+ *  assume control of the input handle. The cuBLAS library must be
+ *  initialized in order to call this function.
+ *
+ *  \param[in] handle The new library handle. Hydrogen will take
+ *                    ownership of the new handle and destroy it in
+ *                    Finalize().
+ *
+ *  \throws std::logic_error If the input handle is null or the
+ *                           library isn't initialized.
+ */
+void ReplaceDenseLibraryHandle(cusolverDnHandle_t handle);
+
+/** @brief Get the cuSolverDn library handle. */
+cusolverDnHandle_t GetDenseLibraryHandle() noexcept;
+
+/** @class SyncManager
+ *  @brief Manage stream synchronization within cuSolverDn.
+ */
+class SyncManager
+{
+public:
+    SyncManager(cusolverDnHandle_t handle, SyncInfo<Device::GPU> const& si);
+    ~SyncManager();
+private:
+    cudaStream_t orig_stream_;
+};// class SyncManager
+
+///@}
+
+}// namespace cusolver
+}// namespace hydrogen
+#endif // HYDROGEN_DEVICE_GPU_CUDA_CUSOLVERMANAGEMENT_HPP_

--- a/include/hydrogen/device/gpu/cuda/cuSOLVERMeta.hpp
+++ b/include/hydrogen/device/gpu/cuda/cuSOLVERMeta.hpp
@@ -1,0 +1,59 @@
+#ifndef HYDROGEN_DEVICE_GPU_CUDA_CUSOLVERMETA_HPP_
+#define HYDROGEN_DEVICE_GPU_CUDA_CUSOLVERMETA_HPP_
+
+#include <El/hydrogen_config.h>
+
+#include <hydrogen/blas/BLAS_Common.hpp>
+#include <hydrogen/meta/MetaUtilities.hpp>
+#include <hydrogen/utils/HalfPrecision.hpp>
+
+#include <cusolverDn.h>
+
+#include "cuBLASMeta.hpp"
+
+namespace hydrogen
+{
+namespace cusolver
+{
+using cublas::NativeType;
+using cublas::HasNativeType;
+
+/** @class IsSupportedType_Base
+ *  @brief Predicate indicating that a type is supported within cuBLAS
+ *         for the given operation.
+ *
+ *  This is used to map internal cuBLAS types to the operations that
+ *  are supported. For example, `float` is always supported but
+ *  `__half` only has support in a few functions.
+ */
+template <typename T, LAPACK_Op op>
+struct IsSupportedType_Base : std::false_type {};
+
+template <LAPACK_Op op>
+struct IsSupportedType_Base<float, op> : std::true_type {};
+template <LAPACK_Op op>
+struct IsSupportedType_Base<double, op> : std::true_type {};
+template <LAPACK_Op op>
+struct IsSupportedType_Base<cuComplex, op> : std::true_type {};
+template <LAPACK_Op op>
+struct IsSupportedType_Base<cuDoubleComplex, op> : std::true_type {};
+
+/** @class IsSupportedType
+ *  @brief Predicate indicating that the given type is compatible with
+ *         cuSOLVER.
+ *
+ *  This is true when either the type is a compatible cuSOLVER type
+ *  (e.g., float) or when it is binarily equivalent to one (e.g.,
+ *  std::complex<float>)..
+ */
+template <typename T, LAPACK_Op op, bool=HasNativeType<T>::value>
+struct IsSupportedType
+    : IsSupportedType_Base<NativeType<T>, op>
+{};
+
+template <typename T, LAPACK_Op op>
+struct IsSupportedType<T,op,false> : std::false_type {};
+
+}// namespace cusolver
+}// namespace hydrogen
+#endif // HYDROGEN_DEVICE_GPU_CUDA_CUSOLVERMETA_HPP_

--- a/include/hydrogen/device/gpu/cuda/cuSOLVERUtil.hpp
+++ b/include/hydrogen/device/gpu/cuda/cuSOLVERUtil.hpp
@@ -1,0 +1,49 @@
+#ifndef HYDROGEN_DEVICE_GPU_CUDA_CUSOLVERUTIL_HPP_
+#define HYDROGEN_DEVICE_GPU_CUDA_CUSOLVERUTIL_HPP_
+
+#include <El/hydrogen_config.h>
+
+#include <cusolverDn.h>
+
+namespace hydrogen
+{
+namespace cusolver
+{
+
+/** @brief cuSOLVER uses ints to represent sizes. */
+using SizeT = int;
+
+/** @brief cuSOLVER uses ints to represent info variables. */
+using InfoT = int;
+
+/** @brief Convert a value to the size type expected by the cuSOLVER
+ *         library.
+ *
+ *  If `HYDROGEN_DO_BOUNDS_CHECKING` is defined, this will do a
+ *  "safe cast" (it will verify that `val` is in the dynamic range of
+ *  `int`. Otherwise it will do a regular static_cast.
+ */
+template <typename T>
+#ifdef HYDROGEN_DO_BOUNDS_CHECKING
+SizeT ToSizeT(T const& val)
+{
+    return narrow_cast<SizeT>(val);
+}
+#else
+SizeT ToSizeT(T const& val) noexcept
+{
+    return static_cast<SizeT>(val);
+}
+#endif // HYDROGEN_DO_BOUNDS_CHECKING
+
+/** @brief Overload to prevent extra work in the case of dynamic range
+ *         checking.
+ */
+inline SizeT ToSizeT(SizeT const& val) noexcept
+{
+    return val;
+}
+
+}// namespace cusolver
+}// namespace hydrogen
+#endif // HYDROGEN_DEVICE_GPU_CUDA_CUSOLVERUTIL_HPP_

--- a/include/hydrogen/device/gpu/cuda/cuSOLVER_API.hpp
+++ b/include/hydrogen/device/gpu/cuda/cuSOLVER_API.hpp
@@ -1,0 +1,48 @@
+#ifndef HYDROGEN_DEVICE_GPU_CUDA_CUSOLVER_API_HPP_
+#define HYDROGEN_DEVICE_GPU_CUDA_CUSOLVER_API_HPP_
+
+#include <El/hydrogen_config.h>
+
+#include <cusolverDn.h>
+
+namespace hydrogen
+{
+namespace cusolver
+{
+
+// These are just for my own readability.
+template <typename T>
+using DeviceArray = T*;
+
+template <typename T>
+using HostPtr = T*;
+
+template <typename T>
+using DevicePtr = T*;
+
+using cusolver_int = int;
+
+// Cholesky factorization
+#define ADD_POTRF_DECL(ScalarType)                      \
+    cusolver_int GetPotrfWorkspaceSize(                 \
+        cusolverDnHandle_t handle,                      \
+        cublasFillMode_t uplo,                          \
+        cusolver_int n,                                 \
+        DeviceArray<ScalarType> A, cusolver_int lda);  \
+    void Potrf(                                         \
+        cusolverDnHandle_t handle,                      \
+        cublasFillMode_t uplo,                          \
+        cusolver_int n,                                 \
+        DeviceArray<ScalarType> A, cusolver_int lda,    \
+        DeviceArray<ScalarType> workspace,              \
+        cusolver_int workspace_size,                    \
+        DevicePtr<cusolver_int> devinfo)
+
+ADD_POTRF_DECL(float);
+ADD_POTRF_DECL(double);
+ADD_POTRF_DECL(cuComplex);
+ADD_POTRF_DECL(cuDoubleComplex);
+
+}// namespace cusolver
+}// namespace hydrogen
+#endif // HYDROGEN_DEVICE_GPU_CUDA_CUSOLVER_API_HPP_

--- a/include/hydrogen/device/gpu/cuda/cuSOLVER_API.hpp
+++ b/include/hydrogen/device/gpu/cuda/cuSOLVER_API.hpp
@@ -28,7 +28,7 @@ using cusolver_int = int;
         cusolverDnHandle_t handle,                      \
         cublasFillMode_t uplo,                          \
         cusolver_int n,                                 \
-        DeviceArray<ScalarType> A, cusolver_int lda);  \
+        DeviceArray<ScalarType> A, cusolver_int lda);   \
     void Potrf(                                         \
         cusolverDnHandle_t handle,                      \
         cublasFillMode_t uplo,                          \

--- a/include/hydrogen/device/gpu/rocm/rocBLASMeta.hpp
+++ b/include/hydrogen/device/gpu/rocm/rocBLASMeta.hpp
@@ -90,13 +90,28 @@ template <BLAS_Op op>
 struct IsSupportedType_Base<double, op> : std::true_type {};
 
 template <>
-struct IsSupportedType_Base<rocblas_float_complex, BLAS_Op::Herk>
+struct IsSupportedType_Base<float, BLAS_Op::HERK>
+    : std::false_type {};
+template <>
+struct IsSupportedType_Base<double, BLAS_Op::HERK>
+    : std::false_type {};
+template <>
+struct IsSupportedType_Base<rocblas_float_complex, BLAS_Op::HERK>
     : std::true_type {};
-struct IsSupportedType_Base<rocblas_double_complex, BLAS_Op::Herk>
+template <>
+struct IsSupportedType_Base<rocblas_double_complex, BLAS_Op::HERK>
     : std::true_type {};
-struct IsSupportedType_Base<rocblas_float_complex, BLAS_Op::Syrk>
+template <>
+struct IsSupportedType_Base<rocblas_float_complex, BLAS_Op::SYRK>
     : std::true_type {};
-struct IsSupportedType_Base<rocblas_double_complex, BLAS_Op::Syrk>
+template <>
+struct IsSupportedType_Base<rocblas_double_complex, BLAS_Op::SYRK>
+    : std::true_type {};
+template <>
+struct IsSupportedType_Base<rocblas_float_complex, BLAS_Op::TRSM>
+    : std::true_type {};
+template <>
+struct IsSupportedType_Base<rocblas_double_complex, BLAS_Op::TRSM>
     : std::true_type {};
 
 #ifdef HYDROGEN_GPU_USE_FP16

--- a/include/hydrogen/device/gpu/rocm/rocBLASMeta.hpp
+++ b/include/hydrogen/device/gpu/rocm/rocBLASMeta.hpp
@@ -88,10 +88,16 @@ template <BLAS_Op op>
 struct IsSupportedType_Base<float, op> : std::true_type {};
 template <BLAS_Op op>
 struct IsSupportedType_Base<double, op> : std::true_type {};
+
 template <>
-struct IsSupportedType_Base<float,BLAS_Op::DGMM> : std::false_type {};
-template <>
-struct IsSupportedType_Base<double,BLAS_Op::DGMM> : std::false_type {};
+struct IsSupportedType_Base<rocblas_float_complex, BLAS_Op::Herk>
+    : std::true_type {};
+struct IsSupportedType_Base<rocblas_double_complex, BLAS_Op::Herk>
+    : std::true_type {};
+struct IsSupportedType_Base<rocblas_float_complex, BLAS_Op::Syrk>
+    : std::true_type {};
+struct IsSupportedType_Base<rocblas_double_complex, BLAS_Op::Syrk>
+    : std::true_type {};
 
 #ifdef HYDROGEN_GPU_USE_FP16
 template <>

--- a/include/hydrogen/device/gpu/rocm/rocBLASUtil.hpp
+++ b/include/hydrogen/device/gpu/rocm/rocBLASUtil.hpp
@@ -66,6 +66,34 @@ ToNativeSideMode(SideMode const& side) noexcept
     return rocblas_side_right;
 }
 
+inline rocblas_fill
+ToNativeFillMode(FillMode const& uplo) noexcept
+{
+    switch (uplo)
+    {
+    case FillMode::UPPER_TRIANGLE:
+        return rocblas_fill_upper;
+    case FillMode::LOWER_TRIANGLE:
+        return rocblas_fill_lower;
+    case FillMode::FULL:
+        return rocblas_fill_full;
+    }
+    return rocblas_fill_full;
+}
+
+inline rocblas_diagonal
+ToNativeDiagType(DiagType const& diag) noexcept
+{
+    switch (diag)
+    {
+    case DiagType::UNIT:
+        return rocblas_diagonal_unit;
+    case DiagType::NON_UNIT:
+        return rocblas_diagonal_non_unit;
+    }
+    return rocblas_diagonal_unit;
+}
+
 }// namespace rocblas
 }// namespace hydrogen
 #endif // HYDROGEN_DEVICE_GPU_ROCM_ROCBLASUTIL_HPP_

--- a/include/hydrogen/device/gpu/rocm/rocBLAS_API.hpp
+++ b/include/hydrogen/device/gpu/rocm/rocBLAS_API.hpp
@@ -81,7 +81,7 @@ ADD_GEMV_DECL(double);
 #define ADD_HERK_DECL(ScalarType, BaseScalarType)               \
     void Herk(                                                  \
         rocblas_handle handle,                                  \
-        rocblas_fill_mode uplo, rocblas_operation trans,        \
+        rocblas_fill uplo, rocblas_operation trans,             \
         rocblas_int n, rocblas_int k,                           \
         BaseScalarType const& alpha,                            \
         ScalarType const* A, rocblas_int lda,                   \
@@ -91,12 +91,22 @@ ADD_GEMV_DECL(double);
 #define ADD_SYRK_DECL(ScalarType)                               \
     void Syrk(                                                  \
         rocblas_handle handle,                                  \
-        rocblas_fill_mode uplo, rocblas_operation trans,        \
+        rocblas_fill uplo, rocblas_operation trans,             \
         rocblas_int n, rocblas_int k,                           \
         ScalarType const& alpha,                                \
         ScalarType const* A, rocblas_int lda,                   \
         ScalarType const& beta,                                 \
         ScalarType* C, rocblas_int ldc)
+
+#define ADD_TRSM_DECL(ScalarType)                             \
+    void Trsm(                                                \
+        rocblas_handle handle,                                \
+        rocblas_side side, rocblas_fill uplo,                 \
+        rocblas_operation trans, rocblas_diagonal diag,       \
+        rocblas_int m, rocblas_int n,                         \
+        ScalarType const& alpha,                              \
+        ScalarType const* A, int lda,                         \
+        ScalarType* B, int ldb)
 
 #define ADD_GEMM_DECL(ScalarType)                       \
     void Gemm(                                          \
@@ -117,6 +127,11 @@ ADD_SYRK_DECL(float);
 ADD_SYRK_DECL(double);
 ADD_SYRK_DECL(rocblas_float_complex);
 ADD_SYRK_DECL(rocblas_double_complex);
+
+ADD_TRSM_DECL(float);
+ADD_TRSM_DECL(double);
+ADD_TRSM_DECL(rocblas_float_complex);
+ADD_TRSM_DECL(rocblas_double_complex);
 
 #ifdef HYDROGEN_GPU_USE_FP16
 ADD_GEMM_DECL(rocblas_half);

--- a/include/hydrogen/device/gpu/rocm/rocBLAS_API.hpp
+++ b/include/hydrogen/device/gpu/rocm/rocBLAS_API.hpp
@@ -13,34 +13,34 @@ namespace rocblas
 /** @name BLAS-1 Routines */
 ///@{
 
-#define ADD_AXPY_DECL(ScalarType)               \
-    void Axpy(rocblas_handle handle,            \
-              int n, ScalarType const& alpha,   \
-              ScalarType const* X, int incx,    \
-              ScalarType* Y, int incy)
+#define ADD_AXPY_DECL(ScalarType)                       \
+    void Axpy(rocblas_handle handle,                    \
+              rocblas_int n, ScalarType const& alpha,   \
+              ScalarType const* X, rocblas_int incx,    \
+              ScalarType* Y, rocblas_int incy)
 
-#define ADD_COPY_DECL(ScalarType)                       \
-    void Copy(rocblas_handle handle,                    \
-              int n, ScalarType const* X, int incx,     \
-              ScalarType* Y, int incy)
+#define ADD_COPY_DECL(ScalarType)                                       \
+    void Copy(rocblas_handle handle,                                    \
+              rocblas_int n, ScalarType const* X, rocblas_int incx,     \
+              ScalarType* Y, rocblas_int incy)
 
-#define ADD_DOT_DECL(ScalarType)                \
-    void Dot(rocblasHandle_t handle,            \
-             int n,                             \
-             ScalarType const* X, int incx,     \
-             ScalarType const* Y, int incy,     \
+#define ADD_DOT_DECL(ScalarType)                        \
+    void Dot(rocblasHandle_t handle,                    \
+             rocblas_int n,                             \
+             ScalarType const* X, rocblas_int incx,     \
+             ScalarType const* Y, rocblas_int incy,     \
              ScalarType* output)
 
-#define ADD_NRM2_DECL(ScalarType)               \
-    void Nrm2(rocblasHandle_t handle,           \
-              int n,                            \
-              ScalarType const* X, int incx,    \
+#define ADD_NRM2_DECL(ScalarType)                       \
+    void Nrm2(rocblasHandle_t handle,                   \
+              rocblas_int n,                            \
+              ScalarType const* X, rocblas_int incx,    \
               ScalarType* output)
 
-#define ADD_SCALE_DECL(ScalarType)                       \
-    void Scale(rocblas_handle handle,                    \
-               int n, ScalarType const& alpha,           \
-               ScalarType* X, int incx)
+#define ADD_SCALE_DECL(ScalarType)                      \
+    void Scale(rocblas_handle handle,                   \
+               rocblas_int n, ScalarType const& alpha,  \
+               ScalarType* X, rocblas_int incx)
 
 #ifdef HYDROGEN_GPU_USE_FP16
 ADD_AXPY_DECL(rocblas_half);
@@ -61,15 +61,15 @@ ADD_SCALE_DECL(double);
 /** @name BLAS-2 Routines */
 ///@{
 
-#define ADD_GEMV_DECL(ScalarType)                       \
-    void Gemv(                                          \
-        rocblas_handle handle,                          \
-        rocblas_operation transpA, int m, int n,        \
-        ScalarType const& alpha,                        \
-        ScalarType const* A, int lda,                   \
-        ScalarType const* x, int incx,                  \
-        ScalarType const& beta,                         \
-        ScalarType* y, int incy)
+#define ADD_GEMV_DECL(ScalarType)                                       \
+    void Gemv(                                                          \
+        rocblas_handle handle,                                          \
+        rocblas_operation transpA, rocblas_int m, rocblas_int n,        \
+        ScalarType const& alpha,                                        \
+        ScalarType const* A, rocblas_int lda,                           \
+        ScalarType const* x, rocblas_int incx,                          \
+        ScalarType const& beta,                                         \
+        ScalarType* y, rocblas_int incy)
 
 ADD_GEMV_DECL(float);
 ADD_GEMV_DECL(double);
@@ -78,17 +78,45 @@ ADD_GEMV_DECL(double);
 /** @name BLAS-3 Routines */
 ///@{
 
-#define ADD_GEMM_DECL(ScalarType)               \
-    void Gemm(                                  \
-        rocblas_handle handle,                  \
-        rocblas_operation transpA,              \
-        rocblas_operation transpB,              \
-        int m, int n, int k,                    \
-        ScalarType const& alpha,                \
-        ScalarType const* A, int lda,           \
-        ScalarType const* B, int ldb,           \
-        ScalarType const& beta,                 \
-        ScalarType* C, int ldc)
+#define ADD_HERK_DECL(ScalarType, BaseScalarType)               \
+    void Herk(                                                  \
+        rocblas_handle handle,                                  \
+        rocblas_fill_mode uplo, rocblas_operation trans,        \
+        rocblas_int n, rocblas_int k,                           \
+        BaseScalarType const& alpha,                            \
+        ScalarType const* A, rocblas_int lda,                   \
+        BaseScalarType const& beta,                             \
+        ScalarType * C, rocblas_int ldc)
+
+#define ADD_SYRK_DECL(ScalarType)                               \
+    void Syrk(                                                  \
+        rocblas_handle handle,                                  \
+        rocblas_fill_mode uplo, rocblas_operation trans,        \
+        rocblas_int n, rocblas_int k,                           \
+        ScalarType const& alpha,                                \
+        ScalarType const* A, rocblas_int lda,                   \
+        ScalarType const& beta,                                 \
+        ScalarType* C, rocblas_int ldc)
+
+#define ADD_GEMM_DECL(ScalarType)                       \
+    void Gemm(                                          \
+        rocblas_handle handle,                          \
+        rocblas_operation transpA,                      \
+        rocblas_operation transpB,                      \
+        rocblas_int m, rocblas_int n, rocblas_int k,    \
+        ScalarType const& alpha,                        \
+        ScalarType const* A, rocblas_int lda,           \
+        ScalarType const* B, rocblas_int ldb,           \
+        ScalarType const& beta,                         \
+        ScalarType* C, rocblas_int ldc)
+
+ADD_HERK_DECL(rocblas_float_complex, float);
+ADD_HERK_DECL(rocblas_double_complex, double);
+
+ADD_SYRK_DECL(float);
+ADD_SYRK_DECL(double);
+ADD_SYRK_DECL(rocblas_float_complex);
+ADD_SYRK_DECL(rocblas_double_complex);
 
 #ifdef HYDROGEN_GPU_USE_FP16
 ADD_GEMM_DECL(rocblas_half);
@@ -101,27 +129,27 @@ ADD_GEMM_DECL(double);
 ///@{
 
 // We use this for Axpy2D, Copy2D, and Transpose
-#define ADD_GEAM_DECL(ScalarType)               \
-    void Geam(rocblas_handle handle,            \
-              rocblas_operation transpA,        \
-              rocblas_operation transpB,        \
-              int m, int n,                     \
-              ScalarType const& alpha,          \
-              ScalarType const* A, int lda,     \
-              ScalarType const& beta,           \
-              ScalarType const* B, int ldb,     \
-              ScalarType* C, int ldc)
+#define ADD_GEAM_DECL(ScalarType)                       \
+    void Geam(rocblas_handle handle,                    \
+              rocblas_operation transpA,                \
+              rocblas_operation transpB,                \
+              rocblas_int m, rocblas_int n,             \
+              ScalarType const& alpha,                  \
+              ScalarType const* A, rocblas_int lda,     \
+              ScalarType const& beta,                   \
+              ScalarType const* B, rocblas_int ldb,     \
+              ScalarType* C, rocblas_int ldc)
 
 ADD_GEAM_DECL(float);
 ADD_GEAM_DECL(double);
 
-#define ADD_DGMM_DECL(ScalarType)               \
-    void Dgmm(rocblas_handle handle,            \
-              rocblas_side side,                \
-              int m, int n,                     \
-              ScalarType const* A, int lda,     \
-              ScalarType const* X, int incx,    \
-              ScalarType* C, int ldc)
+#define ADD_DGMM_DECL(ScalarType)                       \
+    void Dgmm(rocblas_handle handle,                    \
+              rocblas_side side,                        \
+              rocblas_int m, rocblas_int n,             \
+              ScalarType const* A, rocblas_int lda,     \
+              ScalarType const* X, rocblas_int incx,    \
+              ScalarType* C, rocblas_int ldc)
 ADD_DGMM_DECL(float);
 ADD_DGMM_DECL(double);
 

--- a/include/hydrogen/device/gpu/rocm/rocSOLVER.hpp
+++ b/include/hydrogen/device/gpu/rocm/rocSOLVER.hpp
@@ -1,0 +1,12 @@
+#ifndef HYDROGEN_DEVICE_GPU_ROCM_ROCSOLVER_HPP_
+#define HYDROGEN_DEVICE_GPU_ROCM_ROCSOLVER_HPP_
+
+#include "rocSOLVERError.hpp"
+#include "rocSOLVERManagement.hpp"
+#include "rocSOLVERMeta.hpp"
+#include "rocSOLVERUtil.hpp"
+
+// The API wrapper declarations
+#include "rocSOLVER_API.hpp"
+
+#endif // HYDROGEN_DEVICE_GPU_ROCM_ROCSOLVER_HPP_

--- a/include/hydrogen/device/gpu/rocm/rocSOLVERError.hpp
+++ b/include/hydrogen/device/gpu/rocm/rocSOLVERError.hpp
@@ -1,0 +1,14 @@
+#ifndef HYDROGEN_DEVICE_GPU_ROCM_ROCSOLVERERROR_HPP_
+#define HYDROGEN_DEVICE_GPU_ROCM_ROCSOLVERERROR_HPP_
+
+#include "rocBLASError.hpp"
+
+// Helper error-checking macro. Since the statuses are just rocBLAS
+// statuses, just use that macro. Yes, we could get a more precise
+// error class, e.g., "rocSOLVERError", but the command is still
+// printed verbatim, so any user will see that the rocSOLVER call is
+// causing the error. Errrr detecting the error...
+#define H_CHECK_ROCSOLVER(cmd)                                          \
+    H_CHECK_ROCBLAS(cmd)
+
+#endif // HYDROGEN_DEVICE_GPU_ROCM_ROCSOLVERERROR_HPP_

--- a/include/hydrogen/device/gpu/rocm/rocSOLVERManagement.hpp
+++ b/include/hydrogen/device/gpu/rocm/rocSOLVERManagement.hpp
@@ -1,0 +1,71 @@
+#ifndef HYDROGEN_DEVICE_GPU_ROCM_ROCSOLVERMANAGEMENT_HPP_
+#define HYDROGEN_DEVICE_GPU_ROCM_ROCSOLVERMANAGEMENT_HPP_
+
+#include <El/hydrogen_config.h>
+
+#include "rocBLASManagement.hpp"
+#include <rocsolver.h>
+
+namespace hydrogen
+{
+namespace rocsolver
+{
+
+/** @name rocSOLVER management functions. */
+///@{
+
+/** @brief Initialize rocSOLVER's dense interface.
+ *
+ *  Creates the default library instance for rocSolver.
+ *
+ *  rocSOLVER is interesting because it just recycles objects from
+ *  rocBLAS. These are all just pass-throughs to the corresponding
+ *  calls in the hydrogen::rocblas interface, and only one
+ *  rocblas_handle object is used for both rocBLAS and rocSOLVER.
+ *
+ *  @note This must be called after `MPI_Init` is called with
+ *  MVAPICH2-GDR.
+ *
+ *  \param[in] handle The handle to use for rocSolver. If null, a new
+ *                    handle will be created. If not null, it is
+ *                    assumed that the handle has been created with a
+ *                    user-side call to rocblas_create_handle().
+ */
+void InitializeDense(rocblas_handle handle=nullptr);
+
+/** @brief Finalize the rocSolver library.
+ *
+ *  Destroys the default library handle.
+ *
+ *  \throws rocSOLVERError If the rocSOLVER library detects any errors.
+ */
+void FinalizeDense();
+
+/** @brief Replace the default rocSolver library handle.
+ *
+ *  This will destroy the current default rocSOLVER library handle and
+ *  assume control of the input handle. The rocSOLVER library must be
+ *  initialized in order to call this function.
+ *
+ *  \param[in] handle The new library handle. Hydrogen will take
+ *                    ownership of the new handle and destroy it in
+ *                    Finalize().
+ *
+ *  \throws std::logic_error If the input handle is null or the
+ *                           library isn't initialized.
+ */
+void ReplaceDenseLibraryHandle(rocblas_handle handle);
+
+/** @brief Get the rocSolver library handle. */
+rocblas_handle GetDenseLibraryHandle() noexcept;
+
+/** @class SyncManager
+ *  @brief Manage stream synchronization within rocSolver.
+ */
+using SyncManager = rocblas::SyncManager;
+
+///@}
+
+}// namespace rocsolver
+}// namespace hydrogen
+#endif // HYDROGEN_DEVICE_GPU_ROCM_ROCSOLVERMANAGEMENT_HPP_

--- a/include/hydrogen/device/gpu/rocm/rocSOLVERMeta.hpp
+++ b/include/hydrogen/device/gpu/rocm/rocSOLVERMeta.hpp
@@ -1,5 +1,5 @@
-#ifndef HYDROGEN_DEVICE_GPU_CUDA_CUSOLVERMETA_HPP_
-#define HYDROGEN_DEVICE_GPU_CUDA_CUSOLVERMETA_HPP_
+#ifndef HYDROGEN_DEVICE_GPU_ROCM_ROCSOLVERMETA_HPP_
+#define HYDROGEN_DEVICE_GPU_ROCM_ROCSOLVERMETA_HPP_
 
 #include <El/hydrogen_config.h>
 
@@ -7,22 +7,22 @@
 #include <hydrogen/meta/MetaUtilities.hpp>
 #include <hydrogen/utils/HalfPrecision.hpp>
 
-#include <cusolverDn.h>
+#include <rocsolver.h>
 
-#include "cuBLASMeta.hpp"
+#include "rocBLASMeta.hpp"
 
 namespace hydrogen
 {
-namespace cusolver
+namespace rocsolver
 {
-using cublas::NativeType;
-using cublas::HasNativeType;
+using rocblas::NativeType;
+using rocblas::HasNativeType;
 
 /** @class IsSupportedType_Base
- *  @brief Predicate indicating that a type is supported within cuBLAS
- *         for the given operation.
+ *  @brief Predicate indicating that a type is supported within
+ *         rocSOLVER for the given operation.
  *
- *  This is used to map internal cuSOLVER types to the operations that
+ *  This is used to map internal rocSOLVER types to the operations that
  *  are supported.
  */
 template <typename T, LAPACK_Op op>
@@ -33,15 +33,15 @@ struct IsSupportedType_Base<float, op> : std::true_type {};
 template <LAPACK_Op op>
 struct IsSupportedType_Base<double, op> : std::true_type {};
 template <LAPACK_Op op>
-struct IsSupportedType_Base<cuComplex, op> : std::true_type {};
+struct IsSupportedType_Base<rocblas_float_complex, op> : std::true_type {};
 template <LAPACK_Op op>
-struct IsSupportedType_Base<cuDoubleComplex, op> : std::true_type {};
+struct IsSupportedType_Base<rocblas_double_complex, op> : std::true_type {};
 
 /** @class IsSupportedType
  *  @brief Predicate indicating that the given type is compatible with
- *         cuSOLVER.
+ *         rocSOLVER.
  *
- *  This is true when either the type is a compatible cuSOLVER type
+ *  This is true when either the type is a compatible rocSOLVER type
  *  (e.g., float) or when it is binarily equivalent to one (e.g.,
  *  std::complex<float>)..
  */
@@ -51,8 +51,8 @@ struct IsSupportedType
 {};
 
 template <typename T, LAPACK_Op op>
-struct IsSupportedType<T,op,false> : std::false_type {};
+struct IsSupportedType<T, op, false> : std::false_type {};
 
-}// namespace cusolver
+}// namespace rocsolver
 }// namespace hydrogen
-#endif // HYDROGEN_DEVICE_GPU_CUDA_CUSOLVERMETA_HPP_
+#endif // HYDROGEN_DEVICE_GPU_ROCM_ROCSOLVERMETA_HPP_

--- a/include/hydrogen/device/gpu/rocm/rocSOLVERUtil.hpp
+++ b/include/hydrogen/device/gpu/rocm/rocSOLVERUtil.hpp
@@ -1,0 +1,49 @@
+#ifndef HYDROGEN_DEVICE_GPU_ROCM_ROCSOLVERUTIL_HPP_
+#define HYDROGEN_DEVICE_GPU_ROCM_ROCSOLVERUTIL_HPP_
+
+#include <El/hydrogen_config.h>
+
+#include <rocsolver.h>
+
+namespace hydrogen
+{
+namespace rocsolver
+{
+
+/** @brief rocSOLVER uses rocblas_ints to represent sizes. */
+using SizeT = rocblas_int;
+
+/** @brief rocSOLVER uses rocblas_ints to represent info variables. */
+using InfoT = rocblas_int;
+
+/** @brief Convert a value to the size type expected by the rocSOLVER
+ *         library.
+ *
+ *  If `HYDROGEN_DO_BOUNDS_CHECKING` is defined, this will do a
+ *  "safe cast" (it will verify that `val` is in the dynamic range of
+ *  `int`. Otherwise it will do a regular static_cast.
+ */
+template <typename T>
+#ifdef HYDROGEN_DO_BOUNDS_CHECKING
+SizeT ToSizeT(T const& val)
+{
+    return narrow_cast<SizeT>(val);
+}
+#else
+SizeT ToSizeT(T const& val) noexcept
+{
+    return static_cast<SizeT>(val);
+}
+#endif // HYDROGEN_DO_BOUNDS_CHECKING
+
+/** @brief Overload to prevent extra work in the case of dynamic range
+ *         checking.
+ */
+inline SizeT ToSizeT(SizeT const& val) noexcept
+{
+    return val;
+}
+
+}// namespace rocsolver
+}// namespace hydrogen
+#endif // HYDROGEN_DEVICE_GPU_ROCM_ROCSOLVERUTIL_HPP_

--- a/include/hydrogen/device/gpu/rocm/rocSOLVER_API.hpp
+++ b/include/hydrogen/device/gpu/rocm/rocSOLVER_API.hpp
@@ -1,0 +1,51 @@
+#ifndef HYDROGEN_DEVICE_GPU_ROCM_ROCSOLVER_API_HPP_
+#define HYDROGEN_DEVICE_GPU_ROCM_ROCSOLVER_API_HPP_
+
+#include <El/hydrogen_config.h>
+
+#include <rocsolver.h>
+
+namespace hydrogen
+{
+namespace rocsolver
+{
+
+// These are just for my own readability.
+template <typename T>
+using DeviceArray = T*;
+
+template <typename T>
+using HostPtr = T*;
+
+template <typename T>
+using DevicePtr = T*;
+
+using rocsolver_int = rocblas_int;
+
+// Cholesky factorization
+//
+// Due to shortcomings in the rocSOLVER API, the workspace size will
+// always return zero, and the workspace pointer is unused.
+#define ADD_POTRF_DECL(ScalarType)                      \
+    rocblas_int GetPotrfWorkspaceSize(                  \
+        rocblas_handle handle,                          \
+        rocblas_fill uplo,                              \
+        rocblas_int n,                                  \
+        DeviceArray<ScalarType> A, rocblas_int lda);    \
+    void Potrf(                                         \
+        rocblas_handle handle,                          \
+        rocblas_fill uplo,                              \
+        rocblas_int n,                                  \
+        DeviceArray<ScalarType> A, rocblas_int lda,     \
+        DeviceArray<ScalarType> workspace,              \
+        rocblas_int workspace_size,                     \
+        DevicePtr<rocblas_int> devinfo)
+
+ADD_POTRF_DECL(float);
+ADD_POTRF_DECL(double);
+ADD_POTRF_DECL(rocblas_float_complex);
+ADD_POTRF_DECL(rocblas_double_complex);
+
+}// namespace rocsolver
+}// namespace hydrogen
+#endif // HYDROGEN_DEVICE_GPU_ROCM_ROCSOLVER_API_HPP_

--- a/src/blas_like/level2/CMakeLists.txt
+++ b/src/blas_like/level2/CMakeLists.txt
@@ -14,7 +14,7 @@ set_full_path(THIS_DIR_SOURCES
 #  Trmv.cpp
 #  Trr.cpp
 #  Trr2.cpp
-#  Trsv.cpp
+  Trsv.cpp
   )
 
 # Add the subdirectories

--- a/src/blas_like/level3/CMakeLists.txt
+++ b/src/blas_like/level3/CMakeLists.txt
@@ -3,7 +3,7 @@ set_full_path(THIS_DIR_SOURCES
   Gemm.cpp
 #  Hemm.cpp
 #  Her2k.cpp
-#  Herk.cpp
+  Herk.cpp
 #  HermitianFromEVD.cpp
 #  MultiShiftQuasiTrsm.cpp
 #  MultiShiftTrsm.cpp
@@ -12,11 +12,11 @@ set_full_path(THIS_DIR_SOURCES
 #  SafeMultiShiftTrsm.cpp
 #  Symm.cpp
 #  Syr2k.cpp
-#  Syrk.cpp
+  Syrk.cpp
 #  Trdtrmm.cpp
 #  Trmm.cpp
 #  Trr2k.cpp
-#  Trrk.cpp
+  Trrk.cpp
 #  Trsm.cpp
 #  Trstrm.cpp
 #  Trtrmm.cpp

--- a/src/blas_like/level3/CMakeLists.txt
+++ b/src/blas_like/level3/CMakeLists.txt
@@ -17,7 +17,7 @@ set_full_path(THIS_DIR_SOURCES
 #  Trmm.cpp
 #  Trr2k.cpp
   Trrk.cpp
-#  Trsm.cpp
+  Trsm.cpp
 #  Trstrm.cpp
 #  Trtrmm.cpp
 #  TwoSidedTrmm.cpp

--- a/src/blas_like/level3/Herk.cpp
+++ b/src/blas_like/level3/Herk.cpp
@@ -11,65 +11,69 @@
 
 namespace El {
 
-template<typename T>
-void Herk
-( UpperOrLower uplo, Orientation orientation,
-  Base<T> alpha, const Matrix<T>& A, Base<T> beta, Matrix<T>& C )
+template <typename T>
+void Herk(
+    UpperOrLower uplo, Orientation orientation,
+    Base<T> alpha, AbstractMatrix<T> const& A,
+    Base<T> beta, AbstractMatrix<T>& C)
 {
-    EL_DEBUG_CSE
-    Syrk( uplo, orientation, T(alpha), A, T(beta), C, true );
+    EL_DEBUG_CSE;
+    Syrk(uplo, orientation, T(alpha), A, T(beta), C, true);
 }
 
 template<typename T>
-void Herk
-( UpperOrLower uplo, Orientation orientation,
-  Base<T> alpha, const Matrix<T>& A, Matrix<T>& C )
+void Herk(
+    UpperOrLower uplo, Orientation orientation,
+    Base<T> alpha, AbstractMatrix<T> const& A,
+    AbstractMatrix<T>& C)
 {
-    EL_DEBUG_CSE
-    const Int n = ( orientation==NORMAL ? A.Height() : A.Width() );
-    C.Resize( n, n );
-    Zero( C );
-    Syrk( uplo, orientation, T(alpha), A, T(0), C, true );
+    EL_DEBUG_CSE;
+    const Int n = (orientation==NORMAL ? A.Height() : A.Width());
+    C.Resize(n, n);
+    Zero(C);
+    Syrk(uplo, orientation, T(alpha), A, T(0), C, true);
 }
 
 template<typename T>
-void Herk
-( UpperOrLower uplo, Orientation orientation,
-  Base<T> alpha, const AbstractDistMatrix<T>& A,
-  Base<T> beta,        AbstractDistMatrix<T>& C )
+void Herk(
+    UpperOrLower uplo, Orientation orientation,
+    Base<T> alpha, AbstractDistMatrix<T> const& A,
+    Base<T> beta, AbstractDistMatrix<T>& C)
 {
-    EL_DEBUG_CSE
-    Syrk( uplo, orientation, T(alpha), A, T(beta), C, true );
+    EL_DEBUG_CSE;
+    Syrk(uplo, orientation, T(alpha), A, T(beta), C, true);
 }
 
 template<typename T>
-void Herk
-( UpperOrLower uplo, Orientation orientation,
-  Base<T> alpha, const AbstractDistMatrix<T>& A, AbstractDistMatrix<T>& C )
+void Herk(
+    UpperOrLower uplo, Orientation orientation,
+    Base<T> alpha, AbstractDistMatrix<T> const& A,
+    AbstractDistMatrix<T>& C)
 {
-    EL_DEBUG_CSE
-    const Int n = ( orientation==NORMAL ? A.Height() : A.Width() );
-    C.Resize( n, n );
-    Zero( C );
-    Syrk( uplo, orientation, T(alpha), A, T(0), C, true );
+    EL_DEBUG_CSE;
+    const Int n = (orientation==NORMAL ? A.Height() : A.Width());
+    C.Resize(n, n);
+    Zero(C);
+    Syrk(uplo, orientation, T(alpha), A, T(0), C, true);
 }
 
-
-#define PROTO(T) \
-  template void Herk \
-  ( UpperOrLower uplo, Orientation orientation, \
-    Base<T> alpha, const Matrix<T>& A, \
-    Base<T> beta,        Matrix<T>& C ); \
-  template void Herk \
-  ( UpperOrLower uplo, Orientation orientation, \
-    Base<T> alpha, const Matrix<T>& A, Matrix<T>& C ); \
-  template void Herk \
-  ( UpperOrLower uplo, Orientation orientation, \
-    Base<T> alpha, const AbstractDistMatrix<T>& A, AbstractDistMatrix<T>& C ); \
-  template void Herk \
-  ( UpperOrLower uplo, Orientation orientation, \
-    Base<T> alpha, const AbstractDistMatrix<T>& A, \
-    Base<T> beta,        AbstractDistMatrix<T>& C );
+#define PROTO(T)                                        \
+    template void Herk(                                 \
+        UpperOrLower uplo, Orientation orientation,     \
+        Base<T> alpha, AbstractMatrix<T> const& A,      \
+        Base<T> beta, AbstractMatrix<T>& C);            \
+    template void Herk(                                 \
+        UpperOrLower uplo, Orientation orientation,     \
+        Base<T> alpha, AbstractMatrix<T> const& A,      \
+        AbstractMatrix<T>& C);                          \
+    template void Herk(                                 \
+        UpperOrLower uplo, Orientation orientation,     \
+        Base<T> alpha, AbstractDistMatrix<T> const& A,  \
+        AbstractDistMatrix<T>& C);                      \
+    template void Herk(                                 \
+        UpperOrLower uplo, Orientation orientation,     \
+        Base<T> alpha, AbstractDistMatrix<T> const& A,  \
+        Base<T> beta, AbstractDistMatrix<T>& C);
 
 #define EL_ENABLE_DOUBLEDOUBLE
 #define EL_ENABLE_QUADDOUBLE

--- a/src/blas_like/level3/Syrk.cpp
+++ b/src/blas_like/level3/Syrk.cpp
@@ -16,103 +16,225 @@
 #include "./Syrk/UT.hpp"
 
 namespace El {
-
-template<typename T>
-void Syrk
-( UpperOrLower uplo, Orientation orientation,
-  T alpha, const Matrix<T>& A, T beta, Matrix<T>& C, bool conjugate )
+namespace {
+template <typename T, typename=EnableWhen<IsComputeType<T,Device::CPU>>>
+void SyrkImpl_(
+    UpperOrLower uplo, Orientation orientation,
+    T alpha, Matrix<T, Device::CPU> const& A,
+    T beta, Matrix<T, Device::CPU>& C,
+    bool conjugate)
 {
-    EL_DEBUG_CSE
-    EL_DEBUG_ONLY(
-      if( orientation == NORMAL )
-      {
-          if( A.Height() != C.Height() || A.Height() != C.Width() )
-              LogicError("Nonconformal Syrk");
-      }
-      else
-      {
-          if( A.Width() != C.Height() || A.Width() != C.Width() )
-              LogicError("Nonconformal Syrk");
-      }
-    )
-    const char uploChar = UpperOrLowerToChar( uplo );
-    const char transChar = OrientationToChar( orientation );
-    const Int k = ( orientation == NORMAL ? A.Width() : A.Height() );
-    if( conjugate )
+    const char uploChar = UpperOrLowerToChar(uplo);
+    const char transChar = OrientationToChar(orientation);
+    const Int k = (orientation == NORMAL ? A.Width() : A.Height());
+    if (conjugate)
     {
-        blas::Herk
-        ( uploChar, transChar, C.Height(), k,
-          RealPart(alpha), A.LockedBuffer(), A.LDim(),
-          RealPart(beta),  C.Buffer(),       C.LDim() );
+        blas::Herk(uploChar, transChar, C.Height(), k,
+                   RealPart(alpha), A.LockedBuffer(), A.LDim(),
+                   RealPart(beta),  C.Buffer(),       C.LDim());
     }
     else
     {
-        blas::Syrk
-        ( uploChar, transChar, C.Height(), k,
+        blas::Syrk(uploChar, transChar, C.Height(), k,
           alpha, A.LockedBuffer(), A.LDim(),
-          beta,  C.Buffer(),       C.LDim() );
+          beta,  C.Buffer(),       C.LDim());
     }
 }
 
-template<typename T>
-void Syrk
-( UpperOrLower uplo, Orientation orientation,
-  T alpha, const Matrix<T>& A, Matrix<T>& C, bool conjugate )
+template <typename T,
+          typename=EnableUnless<IsComputeType<T,Device::CPU>>,
+          typename=void>
+void SyrkImpl_(
+    UpperOrLower, Orientation ,
+    T, Matrix<T, Device::CPU> const&,
+    T, Matrix<T, Device::CPU>&,
+    bool)
 {
-    EL_DEBUG_CSE
-    const Int n = ( orientation==NORMAL ? A.Height() : A.Width() );
-    C.Resize( n, n );
-    Zero( C );
-    Syrk( uplo, orientation, alpha, A, T(0), C, conjugate );
+    RuntimeError("Function not implemented for type on CPU.");
 }
 
-template<typename T>
-void Syrk
-( UpperOrLower uplo, Orientation orientation,
-  T alpha, const AbstractDistMatrix<T>& A,
-  T beta,        AbstractDistMatrix<T>& C, bool conjugate )
+template <typename T, typename=EnableWhen<IsComputeType<T,Device::GPU>>>
+void SyrkImpl_(
+    UpperOrLower uplo, Orientation orientation,
+    T alpha, Matrix<T, Device::GPU> const& A,
+    T beta, Matrix<T, Device::GPU>& C,
+    bool conjugate)
 {
-    EL_DEBUG_CSE
-    ScaleTrapezoid( beta, uplo, C );
-    if( uplo == LOWER && orientation == NORMAL )
-        syrk::LN( alpha, A, C, conjugate );
-    else if( uplo == LOWER )
-        syrk::LT( alpha, A, C, conjugate );
-    else if( orientation == NORMAL )
-        syrk::UN( alpha, A, C, conjugate );
+    RuntimeError("Function not yet implemented for GPU.");
+}
+
+template <typename T,
+          typename=EnableUnless<IsComputeType<T,Device::GPU>>,
+          typename=void>
+void SyrkImpl_(
+    UpperOrLower, Orientation ,
+    T, Matrix<T, Device::GPU> const&,
+    T, Matrix<T, Device::GPU>&,
+    bool)
+{
+    RuntimeError("Function not implemented for type on GPU.");
+}
+
+}// namespace
+
+template <typename T, Device D>
+void Syrk(
+    UpperOrLower uplo, Orientation orientation,
+    T alpha, Matrix<T, D> const& A,
+    T beta, Matrix<T, D>& C,
+    bool conjugate)
+{
+    EL_DEBUG_CSE;
+#ifndef EL_RELEASE
+    if (orientation == NORMAL)
+    {
+        if (A.Height() != C.Height() || A.Height() != C.Width())
+            LogicError("Nonconformal Syrk");
+    }
     else
-        syrk::UT( alpha, A, C, conjugate );
+    {
+        if (A.Width() != C.Height() || A.Width() != C.Width())
+            LogicError("Nonconformal Syrk");
+    }
+#endif // not defined EL_RELEASE
+    auto multisync = MakeMultiSync(SyncInfoFromMatrix(C),
+                                   SyncInfoFromMatrix(A));
+    SyrkImpl_(uplo, orientation, alpha, A, beta, C, conjugate);
 }
 
-template<typename T>
-void Syrk
-( UpperOrLower uplo, Orientation orientation,
-  T alpha, const AbstractDistMatrix<T>& A,
-                 AbstractDistMatrix<T>& C, bool conjugate )
+template <typename T, Device D>
+void Syrk(
+    UpperOrLower uplo, Orientation orientation,
+    T alpha, Matrix<T,D> const& A,
+    Matrix<T,D>& C,
+    bool conjugate)
+{
+    EL_DEBUG_CSE;
+    Int const n = (orientation==NORMAL ? A.Height() : A.Width());
+    C.Resize(n, n);
+    // FIXME(trb 07/20/2020): I don't think we need this. According to
+    // cuBLAS docs, if beta==0, the input doesn't have to be
+    // valid. According to netlib source code, the same is
+    // true. Assuming other implementations are similarly robust, we
+    // should be ok with out this.
+    //
+    // Zero(C);
+    Syrk(uplo, orientation, alpha, A, T(0), C, conjugate);
+}
+
+template <typename T>
+void Syrk(
+    UpperOrLower uplo, Orientation orientation,
+    T alpha, AbstractMatrix<T> const& A,
+    AbstractMatrix<T>& C,
+    bool conjugate)
+{
+    switch (A.GetDevice())
+    {
+    case Device::CPU:
+        Syrk(uplo, orientation,
+             alpha,
+             static_cast<Matrix<T,Device::CPU> const&>(A),
+             static_cast<Matrix<T,Device::CPU>&>(C),
+             conjugate);
+        break;
+#ifdef HYDROGEN_HAVE_GPU
+    case Device::GPU:
+        Syrk(uplo, orientation,
+             alpha,
+             static_cast<Matrix<T,Device::GPU> const&>(A),
+             static_cast<Matrix<T,Device::GPU>&>(C),
+             conjugate);
+        break;
+#endif // HYDROGEN_HAVE_GPU
+    default:
+        RuntimeError("Invalid device.");
+    }
+}
+
+template <typename T>
+void Syrk(
+    UpperOrLower uplo, Orientation orientation,
+    T alpha, AbstractMatrix<T> const& A,
+    T beta, AbstractMatrix<T>& C,
+    bool conjugate)
+{
+    switch (A.GetDevice())
+    {
+    case Device::CPU:
+        Syrk(uplo, orientation,
+             alpha, static_cast<Matrix<T,Device::CPU> const&>(A),
+             beta, static_cast<Matrix<T,Device::CPU>&>(C),
+             conjugate);
+        break;
+#ifdef HYDROGEN_HAVE_GPU
+    case Device::GPU:
+        Syrk(uplo, orientation,
+             alpha, static_cast<Matrix<T,Device::GPU> const&>(A),
+             beta, static_cast<Matrix<T,Device::GPU>&>(C),
+             conjugate);
+        break;
+#endif // HYDROGEN_HAVE_GPU
+    default:
+        RuntimeError("Invalid device.");
+    }
+}
+
+template <typename T>
+void Syrk(
+    UpperOrLower uplo, Orientation orientation,
+    T alpha, AbstractDistMatrix<T> const& A,
+    T beta, AbstractDistMatrix<T>& C,
+    bool conjugate)
+{
+    EL_DEBUG_CSE;
+    ScaleTrapezoid(beta, uplo, C);
+    if (uplo == LOWER && orientation == NORMAL)
+        syrk::LN(alpha, A, C, conjugate);
+    else if (uplo == LOWER)
+        syrk::LT(alpha, A, C, conjugate);
+    else if (orientation == NORMAL)
+        syrk::UN(alpha, A, C, conjugate);
+    else
+        syrk::UT(alpha, A, C, conjugate);
+}
+
+template <typename T>
+void Syrk(
+    UpperOrLower uplo, Orientation orientation,
+    T alpha, AbstractDistMatrix<T> const& A,
+    AbstractDistMatrix<T>& C, bool conjugate)
 {
     EL_DEBUG_CSE
-    const Int n = ( orientation==NORMAL ? A.Height() : A.Width() );
-    C.Resize( n, n );
-    Zero( C );
-    Syrk( uplo, orientation, alpha, A, T(0), C, conjugate );
+    const Int n = (orientation==NORMAL ? A.Height() : A.Width());
+    C.Resize(n, n);
+    Zero(C);
+    Syrk(uplo, orientation, alpha, A, T(0), C, conjugate);
 }
 
+#ifdef HYDROGEN_HAVE_GPU
 
-#define PROTO(T) \
-  template void Syrk \
-  ( UpperOrLower uplo, Orientation orientation, \
-    T alpha, const Matrix<T>& A, T beta, Matrix<T>& C, bool conjugate ); \
-  template void Syrk \
-  ( UpperOrLower uplo, Orientation orientation, \
-    T alpha, const Matrix<T>& A, Matrix<T>& C, bool conjugate ); \
-  template void Syrk \
-  ( UpperOrLower uplo, Orientation orientation, \
-    T alpha, const AbstractDistMatrix<T>& A, \
-    T beta, AbstractDistMatrix<T>& C, bool conjugate ); \
-  template void Syrk \
-  ( UpperOrLower uplo, Orientation orientation, \
-    T alpha, const AbstractDistMatrix<T>& A, \
-                   AbstractDistMatrix<T>& C, bool conjugate );
+#else
+
+#endif // HYDROGEN_HAVE_GPU
+
+#define PROTO(T)                                                        \
+    template void Syrk(                                                 \
+        UpperOrLower uplo, Orientation orientation,                     \
+        T alpha, AbstractMatrix<T> const& A,                            \
+        T beta, AbstractMatrix<T>& C, bool conjugate);                  \
+    template void Syrk(                                                 \
+        UpperOrLower uplo, Orientation orientation,                     \
+        T alpha, AbstractMatrix<T> const& A,                            \
+        AbstractMatrix<T>& C, bool conjugate);                          \
+    template void Syrk(                                                 \
+        UpperOrLower uplo, Orientation orientation,                     \
+        T alpha, AbstractDistMatrix<T> const& A,                        \
+        T beta, AbstractDistMatrix<T>& C, bool conjugate);              \
+    template void Syrk(                                                 \
+        UpperOrLower uplo, Orientation orientation,                     \
+        T alpha, AbstractDistMatrix<T> const& A,                        \
+        AbstractDistMatrix<T>& C, bool conjugate);
 
 #define EL_ENABLE_DOUBLEDOUBLE
 #define EL_ENABLE_QUADDOUBLE

--- a/src/blas_like/level3/Trrk.cpp
+++ b/src/blas_like/level3/Trrk.cpp
@@ -1,10 +1,10 @@
 /*
-   Copyright (c) 2009-2016, Jack Poulson
-   All rights reserved.
+  Copyright (c) 2009-2016, Jack Poulson
+  All rights reserved.
 
-   This file is part of Elemental and is under the BSD 2-Clause License, 
-   which can be found in the LICENSE file in the root directory, or at 
-   http://opensource.org/licenses/BSD-2-Clause
+  This file is part of Elemental and is under the BSD 2-Clause License,
+  which can be found in the LICENSE file in the root directory, or at
+  http://opensource.org/licenses/BSD-2-Clause
 */
 #include <El-lite.hpp>
 #include <El/blas_like/level1.hpp>
@@ -19,136 +19,142 @@
 namespace El {
 
 template<typename T>
-void TrrkInternal
-( UpperOrLower uplo, 
-  Orientation orientA, Orientation orientB,
-  T alpha, const Matrix<T>& A, const Matrix<T>& B,
-  T beta,        Matrix<T>& C )
+void TrrkInternal(
+    UpperOrLower uplo,
+    Orientation orientA, Orientation orientB,
+    T alpha, Matrix<T,Device::CPU> const& A, Matrix<T,Device::CPU> const& B,
+    T beta, Matrix<T>& C)
 {
-    EL_DEBUG_CSE
-    ScaleTrapezoid( beta, uplo, C );
-    if( orientA==NORMAL && orientB==NORMAL )
-        trrk::TrrkNN( uplo, alpha, A, B, C );
-    else if( orientA==NORMAL )
-        trrk::TrrkNT( uplo, orientB, alpha, A, B, C );
-    else if( orientB==NORMAL )
-        trrk::TrrkTN( uplo, orientA, alpha, A, B, C );
+    EL_DEBUG_CSE;
+    ScaleTrapezoid(beta, uplo, C);
+    if (orientA==NORMAL && orientB==NORMAL)
+        trrk::TrrkNN(uplo, alpha, A, B, C);
+    else if (orientA==NORMAL)
+        trrk::TrrkNT(uplo, orientB, alpha, A, B, C);
+    else if (orientB==NORMAL)
+        trrk::TrrkTN(uplo, orientA, alpha, A, B, C);
     else
-        trrk::TrrkTT( uplo, orientA, orientB, alpha, A, B, C );
+        trrk::TrrkTT(uplo, orientA, orientB, alpha, A, B, C);
 }
 
 #ifdef HYDROGEN_HAVE_MKL_GEMMT
 template<typename T,typename=EnableIf<IsBlasScalar<T>>>
-void TrrkMKL
-( UpperOrLower uplo, 
-  Orientation orientA, Orientation orientB,
-  T alpha, const Matrix<T>& A, const Matrix<T>& B,
-  T beta,        Matrix<T>& C )
+void TrrkMKL(
+    UpperOrLower uplo,
+    Orientation orientA, Orientation orientB,
+    T alpha, Matrix<T,Device::CPU> const& A, Matrix<T,Device::CPU> const& B,
+    T beta,        Matrix<T>& C)
 {
-    EL_DEBUG_CSE
-    const char uploChar = UpperOrLowerToChar( uplo );
-    const char orientAChar = OrientationToChar( orientA );
-    const char orientBChar = OrientationToChar( orientB );
+    EL_DEBUG_CSE;
+    const char uploChar = UpperOrLowerToChar(uplo);
+    const char orientAChar = OrientationToChar(orientA);
+    const char orientBChar = OrientationToChar(orientB);
     const auto n = C.Height();
-    const auto k = orientA == NORMAL ? A.Width() : A.Height(); 
-    mkl::Trrk 
-    ( uploChar, orientAChar, orientBChar,
-      n, k, 
-      alpha, A.LockedBuffer(), A.LDim(),
-             B.LockedBuffer(), B.LDim(),
-      beta,  C.Buffer(),       C.LDim() );
+    const auto k = orientA == NORMAL ? A.Width() : A.Height();
+    mkl::Trrk
+        (uploChar, orientAChar, orientBChar,
+         n, k,
+         alpha, A.LockedBuffer(), A.LDim(),
+         B.LockedBuffer(), B.LDim(),
+         beta,  C.Buffer(),       C.LDim());
 }
 #endif
 
 template<typename T,typename=EnableIf<IsBlasScalar<T>>>
-void TrrkHelper
-( UpperOrLower uplo, 
-  Orientation orientA, Orientation orientB,
-  T alpha, const Matrix<T>& A, const Matrix<T>& B,
-  T beta,        Matrix<T>& C )
+void TrrkHelper(
+    UpperOrLower uplo,
+    Orientation orientA, Orientation orientB,
+    T alpha, Matrix<T,Device::CPU> const& A, Matrix<T,Device::CPU> const& B,
+    T beta, Matrix<T>& C)
 {
-    EL_DEBUG_CSE
+    EL_DEBUG_CSE;
 #ifdef HYDROGEN_HAVE_MKL_GEMMT
-    TrrkMKL( uplo, orientA, orientB, alpha, A, B, beta, C );
+    TrrkMKL(uplo, orientA, orientB, alpha, A, B, beta, C);
 #else
-    TrrkInternal( uplo, orientA, orientB, alpha, A, B, beta, C );
+    TrrkInternal(uplo, orientA, orientB, alpha, A, B, beta, C);
 #endif
 }
 
 template<typename T,typename=DisableIf<IsBlasScalar<T>>,typename=void>
-void TrrkHelper
-( UpperOrLower uplo, 
-  Orientation orientA, Orientation orientB,
-  T alpha, const Matrix<T>& A, const Matrix<T>& B,
-  T beta,        Matrix<T>& C )
+void TrrkHelper(
+    UpperOrLower uplo,
+    Orientation orientA, Orientation orientB,
+    T alpha, Matrix<T,Device::CPU> const& A, Matrix<T,Device::CPU> const& B,
+    T beta, Matrix<T>& C)
 {
-    EL_DEBUG_CSE
-    TrrkInternal( uplo, orientA, orientB, alpha, A, B, beta, C );
+    EL_DEBUG_CSE;
+    TrrkInternal(uplo, orientA, orientB, alpha, A, B, beta, C);
 }
 
 template<typename T>
-void Trrk
-( UpperOrLower uplo, 
-  Orientation orientA, Orientation orientB,
-  T alpha, const Matrix<T>& A, const Matrix<T>& B,
-  T beta,        Matrix<T>& C )
+void Trrk(
+    UpperOrLower uplo,
+    Orientation orientA, Orientation orientB,
+    T alpha, Matrix<T,Device::CPU> const& A, Matrix<T,Device::CPU> const& B,
+    T beta, Matrix<T>& C)
 {
-    EL_DEBUG_CSE
-    TrrkHelper( uplo, orientA, orientB, alpha, A, B, beta, C );
+    EL_DEBUG_CSE;
+    TrrkHelper(uplo, orientA, orientB, alpha, A, B, beta, C);
 }
 
 template<typename T>
-void Trrk
-( UpperOrLower uplo, Orientation orientA, Orientation orientB,
-  T alpha, const AbstractDistMatrix<T>& A, const AbstractDistMatrix<T>& B,
-  T beta,        AbstractDistMatrix<T>& C )
+void Trrk(
+    UpperOrLower uplo, Orientation orientA, Orientation orientB,
+    T alpha, AbstractDistMatrix<T> const& A, AbstractDistMatrix<T> const& B,
+    T beta, AbstractDistMatrix<T>& C)
 {
-    EL_DEBUG_CSE
-    ScaleTrapezoid( beta, uplo, C );
-    if( orientA==NORMAL && orientB==NORMAL )
-        trrk::TrrkNN( uplo, alpha, A, B, C );
-    else if( orientA==NORMAL )
-        trrk::TrrkNT( uplo, orientB, alpha, A, B, C );
-    else if( orientB==NORMAL )
-        trrk::TrrkTN( uplo, orientA, alpha, A, B, C );
+    EL_DEBUG_CSE;
+    ScaleTrapezoid(beta, uplo, C);
+    if (orientA==NORMAL && orientB==NORMAL)
+        trrk::TrrkNN(uplo, alpha, A, B, C);
+    else if (orientA==NORMAL)
+        trrk::TrrkNT(uplo, orientB, alpha, A, B, C);
+    else if (orientB==NORMAL)
+        trrk::TrrkTN(uplo, orientA, alpha, A, B, C);
     else
-        trrk::TrrkTT( uplo, orientA, orientB, alpha, A, B, C );
+        trrk::TrrkTT(uplo, orientA, orientB, alpha, A, B, C);
 }
 
-#define PROTO(T) \
-  template void Trrk \
-  ( UpperOrLower uplo, \
-    Orientation orientA, Orientation orientB, \
-    T alpha, const Matrix<T>& A, \
-             const Matrix<T>& B, \
-    T beta,        Matrix<T>& C ); \
-  template void Trrk \
-  ( UpperOrLower uplo, \
-    Orientation orientA, Orientation orientB, \
-    T alpha, const AbstractDistMatrix<T>& A, \
-             const AbstractDistMatrix<T>& B, \
-    T beta,        AbstractDistMatrix<T>& C ); \
-  template void LocalTrrk \
-   ( UpperOrLower uplo, \
-     T alpha, const DistMatrix<T,MC,  STAR>& A, \
-              const DistMatrix<T,STAR,MR  >& B, \
-     T beta,        DistMatrix<T>& C ); \
-  template void LocalTrrk \
-  ( UpperOrLower uplo, Orientation orientB, \
-    T alpha, const DistMatrix<T,MC,STAR>& A, \
-             const DistMatrix<T,MR,STAR>& B, \
-    T beta,        DistMatrix<T>& C ); \
-  template void LocalTrrk \
-  ( UpperOrLower uplo, Orientation orientA, \
-    T alpha, const DistMatrix<T,STAR,MC>& A, \
-             const DistMatrix<T,STAR,MR>& B, \
-    T beta,        DistMatrix<T>& C ); \
-  template void LocalTrrk \
-  ( UpperOrLower uplo, \
-    Orientation orientA, Orientation orientB, \
-    T alpha, const DistMatrix<T,STAR,MC  >& A, \
-             const DistMatrix<T,MR,  STAR>& B, \
-    T beta,        DistMatrix<T>& C );
+#define PROTO(T)                                        \
+    template void Trrk(                                 \
+        UpperOrLower uplo,                              \
+        Orientation orientA, Orientation orientB,       \
+        T alpha,                                        \
+        Matrix<T,Device::CPU> const& A,                 \
+        Matrix<T,Device::CPU> const& B,                 \
+        T beta, Matrix<T>& C);                          \
+    template void Trrk(                                 \
+        UpperOrLower uplo,                              \
+        Orientation orientA, Orientation orientB,       \
+        T alpha,                                        \
+        AbstractDistMatrix<T> const& A,                 \
+        AbstractDistMatrix<T> const& B,                 \
+        T beta, AbstractDistMatrix<T>& C);              \
+    template void LocalTrrk(                            \
+        UpperOrLower uplo,                              \
+        T alpha,                                        \
+        DistMatrix<T,MC,  STAR> const& A,               \
+        DistMatrix<T,STAR,MR  > const& B,               \
+        T beta, DistMatrix<T>& C);                      \
+    template void LocalTrrk(                            \
+        UpperOrLower uplo, Orientation orientB,         \
+        T alpha,                                        \
+        DistMatrix<T,MC,STAR> const& A,                 \
+        DistMatrix<T,MR,STAR> const& B,                 \
+        T beta, DistMatrix<T>& C);                      \
+    template void LocalTrrk(                            \
+        UpperOrLower uplo, Orientation orientA,         \
+        T alpha,                                        \
+        DistMatrix<T,STAR,MC> const& A,                 \
+        DistMatrix<T,STAR,MR> const& B,                 \
+        T beta, DistMatrix<T>& C);                      \
+    template void LocalTrrk(                            \
+        UpperOrLower uplo,                              \
+        Orientation orientA, Orientation orientB,       \
+        T alpha,                                        \
+        DistMatrix<T,STAR,MC  > const& A,               \
+        DistMatrix<T,MR,  STAR> const& B,               \
+        T beta, DistMatrix<T>& C);
 
 #define EL_ENABLE_DOUBLEDOUBLE
 #define EL_ENABLE_QUADDOUBLE

--- a/src/blas_like/level3/Trrk/Local.hpp
+++ b/src/blas_like/level3/Trrk/Local.hpp
@@ -2,8 +2,8 @@
    Copyright (c) 2009-2016, Jack Poulson
    All rights reserved.
 
-   This file is part of Elemental and is under the BSD 2-Clause License, 
-   which can be found in the LICENSE file in the root directory, or at 
+   This file is part of Elemental and is under the BSD 2-Clause License,
+   which can be found in the LICENSE file in the root directory, or at
    http://opensource.org/licenses/BSD-2-Clause
 */
 #ifndef EL_TRRK_LOCAL_HPP
@@ -19,52 +19,52 @@ namespace trrk {
 
 template<typename T>
 void EnsureConformal
-( const DistMatrix<T,MC,STAR>& A, const DistMatrix<T>& C, string name )
+(const DistMatrix<T,MC,STAR>& A, const DistMatrix<T>& C, string name)
 {
-    if( A.Height() != C.Height() || A.ColAlign() != C.ColAlign() )
+    if (A.Height() != C.Height() || A.ColAlign() != C.ColAlign())
         LogicError(name," not conformal with C");
 }
 
 template<typename T>
 void EnsureConformal
-( const DistMatrix<T,STAR,MC>& A, const DistMatrix<T>& C, string name )
+(const DistMatrix<T,STAR,MC>& A, const DistMatrix<T>& C, string name)
 {
-    if( A.Width() != C.Height() || A.RowAlign() != C.ColAlign() )
+    if (A.Width() != C.Height() || A.RowAlign() != C.ColAlign())
         LogicError(name," not conformal with C");
 }
 
 template<typename T>
 void EnsureConformal
-( const DistMatrix<T,MR,STAR>& A, const DistMatrix<T>& C, string name )
+(const DistMatrix<T,MR,STAR>& A, const DistMatrix<T>& C, string name)
 {
-    if( A.Height() != C.Width() || A.ColAlign() != C.RowAlign() )
+    if (A.Height() != C.Width() || A.ColAlign() != C.RowAlign())
         LogicError(name," not conformal with C");
 }
 
 template<typename T>
 void EnsureConformal
-( const DistMatrix<T,STAR,MR>& A, const DistMatrix<T>& C, string name )
+(const DistMatrix<T,STAR,MR>& A, const DistMatrix<T>& C, string name)
 {
-    if( A.Width() != C.Width() || A.RowAlign() != C.RowAlign() )
+    if (A.Width() != C.Width() || A.RowAlign() != C.RowAlign())
         LogicError(name," not conformal with C");
 }
 
 template<typename T,Dist UA,Dist VA,Dist UB,Dist VB>
 void CheckInput
-( const DistMatrix<T,UA,VA>& A, const DistMatrix<T,UB,VB>& B,
-  const DistMatrix<T>& C )
+(const DistMatrix<T,UA,VA>& A, const DistMatrix<T,UB,VB>& B,
+  const DistMatrix<T>& C)
 {
-    AssertSameGrids( A, B, C );
-    EnsureConformal( A, C, "A" );
-    EnsureConformal( B, C, "B" );
+    AssertSameGrids(A, B, C);
+    EnsureConformal(A, C, "A");
+    EnsureConformal(B, C, "B");
 }
 
 // Local C := A B + C
 template<typename T>
-void CheckInputNN( const Matrix<T>& A, const Matrix<T>& B, const Matrix<T>& C )
+void CheckInputNN(const Matrix<T>& A, const Matrix<T>& B, const Matrix<T>& C)
 {
-    if( A.Height() != C.Height() || B.Width()  != C.Width() ||
-        A.Width()  != B.Height() || A.Height() != B.Width() )
+    if (A.Height() != C.Height() || B.Width()  != C.Width() ||
+        A.Width()  != B.Height() || A.Height() != B.Width())
         LogicError
         ("Nonconformal LocalTrrk:\n",
          DimsString(A,"A"),"\n",DimsString(B,"B"),"\n",DimsString(C,"C"));
@@ -73,13 +73,13 @@ void CheckInputNN( const Matrix<T>& A, const Matrix<T>& B, const Matrix<T>& C )
 // Local C := A B^{T/H} + C
 template<typename T>
 void CheckInputNT
-( Orientation orientationOfB,
-  const Matrix<T>& A, const Matrix<T>& B, const Matrix<T>& C )
+(Orientation orientationOfB,
+  const Matrix<T>& A, const Matrix<T>& B, const Matrix<T>& C)
 {
-    if( orientationOfB == NORMAL )
+    if (orientationOfB == NORMAL)
         LogicError("B must be (Conjugate)Transpose'd");
-    if( A.Height() != C.Height() || B.Height() != C.Width() ||
-        A.Width()  != B.Width()  || A.Height() != B.Height() )
+    if (A.Height() != C.Height() || B.Height() != C.Width() ||
+        A.Width()  != B.Width()  || A.Height() != B.Height())
         LogicError
         ("Nonconformal LocalTrrk:\n",
          DimsString(A,"A"),"\n",DimsString(B,"B"),"\n",DimsString(C,"C"));
@@ -88,13 +88,13 @@ void CheckInputNT
 // Local C := A^{T/H} B + C
 template<typename T>
 void CheckInputTN
-( Orientation orientationOfA,
-  const Matrix<T>& A, const Matrix<T>& B, const Matrix<T>& C )
+(Orientation orientationOfA,
+  const Matrix<T>& A, const Matrix<T>& B, const Matrix<T>& C)
 {
-    if( orientationOfA == NORMAL )
+    if (orientationOfA == NORMAL)
         LogicError("A must be (Conjugate)Transpose'd");
-    if( A.Width() != C.Height() || B.Width() != C.Width() ||
-        A.Height() != B.Height() || A.Width() != B.Width() )
+    if (A.Width() != C.Height() || B.Width() != C.Width() ||
+        A.Height() != B.Height() || A.Width() != B.Width())
         LogicError
         ("Nonconformal LocalTrrk:\n",
          DimsString(A,"A"),"\n",DimsString(B,"B"),"\n",DimsString(C,"C"));
@@ -103,16 +103,16 @@ void CheckInputTN
 // Local C := A^{T/H} B^{T/H} + C
 template<typename T>
 void CheckInputTT
-( Orientation orientationOfA,
+(Orientation orientationOfA,
   Orientation orientationOfB,
-  const Matrix<T>& A, const Matrix<T>& B, const Matrix<T>& C )
+  const Matrix<T>& A, const Matrix<T>& B, const Matrix<T>& C)
 {
-    if( orientationOfA == NORMAL )
+    if (orientationOfA == NORMAL)
         LogicError("A must be (Conjugate)Transpose'd");
-    if( orientationOfB == NORMAL )
+    if (orientationOfB == NORMAL)
         LogicError("B must be (Conjugate)Transpose'd");
-    if( A.Width() != C.Height() || B.Height() != C.Width() ||
-        A.Height() != B.Width() || A.Width() != B.Height() )
+    if (A.Width() != C.Height() || B.Height() != C.Width() ||
+        A.Height() != B.Width() || A.Width() != B.Height())
         LogicError
         ("Nonconformal LocalTrrk:\n",
          DimsString(A,"A"),"\n",DimsString(B,"B"),"\n",DimsString(C,"C"));
@@ -123,12 +123,12 @@ void CheckInputTT
 // Local C := alpha A B + C
 template<typename T>
 void TrrkNNKernel
-( UpperOrLower uplo, 
+(UpperOrLower uplo,
   T alpha, const Matrix<T>& A, const Matrix<T>& B,
-                 Matrix<T>& C )
+                 Matrix<T>& C)
 {
     EL_DEBUG_CSE
-    EL_DEBUG_ONLY(CheckInputNN( A, B, C ))
+    EL_DEBUG_ONLY(CheckInputNN(A, B, C))
 
     const Int half = C.Height()/2;
     const auto indTL = IR(0,half);
@@ -141,38 +141,38 @@ void TrrkNNKernel
     auto CTL = C(indTL,indTL);
     auto CBR = C(indBR,indBR);
 
-    if( uplo == LOWER )
+    if (uplo == LOWER)
     {
         auto CBL = C(indBR,indTL);
-        Gemm( NORMAL, NORMAL, alpha, AB, BL, T(1), CBL );
+        Gemm(NORMAL, NORMAL, alpha, AB, BL, T(1), CBL);
     }
     else
     {
         auto CTR = C(indTL,indBR);
-        Gemm( NORMAL, NORMAL, alpha, AT, BR, T(1), CTR );
+        Gemm(NORMAL, NORMAL, alpha, AT, BR, T(1), CTR);
     }
 
     // TODO(poulson): Avoid the temporary copy
     Matrix<T> DTL;
-    Gemm( NORMAL, NORMAL, alpha, AT, BL, DTL );
-    AxpyTrapezoid( uplo, T(1), DTL, CTL );
+    Gemm(NORMAL, NORMAL, alpha, AT, BL, DTL);
+    AxpyTrapezoid(uplo, T(1), DTL, CTL);
 
     // TODO(poulson): Avoid the temporary copy
     Matrix<T> DBR;
-    Gemm( NORMAL, NORMAL, alpha, AB, BR, DBR );
-    AxpyTrapezoid( uplo, T(1), DBR, CBR );
+    Gemm(NORMAL, NORMAL, alpha, AB, BR, DBR);
+    AxpyTrapezoid(uplo, T(1), DBR, CBR);
 }
 
 // Distributed C := alpha A B + C
 template<typename T>
 void LocalTrrkKernel
-( UpperOrLower uplo, 
+(UpperOrLower uplo,
   T alpha, const DistMatrix<T,MC,  STAR>& A,
            const DistMatrix<T,STAR,MR  >& B,
-                 DistMatrix<T>& C )
+                 DistMatrix<T>& C)
 {
     EL_DEBUG_CSE
-    EL_DEBUG_ONLY(CheckInput( A, B, C ))
+    EL_DEBUG_ONLY(CheckInput(A, B, C))
     const Grid& g = C.Grid();
 
     const Int half = C.Height()/2;
@@ -186,40 +186,40 @@ void LocalTrrkKernel
     auto CTL = C(indTL,indTL);
     auto CBR = C(indBR,indBR);
 
-    if( uplo == LOWER )
+    if (uplo == LOWER)
     {
         auto CBL = C(indBR,indTL);
-        LocalGemm( NORMAL, NORMAL, alpha, AB, BL, T(1), CBL );
+        LocalGemm(NORMAL, NORMAL, alpha, AB, BL, T(1), CBL);
     }
     else
     {
         auto CTR = C(indTL,indBR);
-        LocalGemm( NORMAL, NORMAL, alpha, AT, BR, T(1), CTR );
+        LocalGemm(NORMAL, NORMAL, alpha, AT, BR, T(1), CTR);
     }
 
     // TODO(poulson): Avoid the temporary copy
     DistMatrix<T> DTL(g);
-    DTL.AlignWith( CTL );
-    LocalGemm( NORMAL, NORMAL, alpha, AT, BL, DTL );
-    LocalAxpyTrapezoid( uplo, T(1), DTL, CTL );
+    DTL.AlignWith(CTL);
+    LocalGemm(NORMAL, NORMAL, alpha, AT, BL, DTL);
+    LocalAxpyTrapezoid(uplo, T(1), DTL, CTL);
 
     // TODO(poulson): Avoid the temporary copy
     DistMatrix<T> DBR(g);
-    DBR.AlignWith( CBR );
-    LocalGemm( NORMAL, NORMAL, alpha, AB, BR, DBR );
-    LocalAxpyTrapezoid( uplo, T(1), DBR, CBR );
+    DBR.AlignWith(CBR);
+    LocalGemm(NORMAL, NORMAL, alpha, AB, BR, DBR);
+    LocalAxpyTrapezoid(uplo, T(1), DBR, CBR);
 }
 
 // Local C := alpha A B^{T/H} + C
 template<typename T>
 void TrrkNTKernel
-( UpperOrLower uplo,
+(UpperOrLower uplo,
   Orientation orientationOfB,
   T alpha, const Matrix<T>& A, const Matrix<T>& B,
-                 Matrix<T>& C )
+                 Matrix<T>& C)
 {
     EL_DEBUG_CSE
-    EL_DEBUG_ONLY(CheckInputNT( orientationOfB, A, B, C ))
+    EL_DEBUG_ONLY(CheckInputNT(orientationOfB, A, B, C))
 
     const Int half = C.Height()/2;
     const auto indTL = IR(0,half);
@@ -232,39 +232,39 @@ void TrrkNTKernel
     auto CTL = C(indTL,indTL);
     auto CBR = C(indBR,indBR);
 
-    if( uplo == LOWER )
+    if (uplo == LOWER)
     {
         auto CBL = C(indBR,indTL);
-        Gemm( NORMAL, orientationOfB, alpha, AB, BT, T(1), CBL );
+        Gemm(NORMAL, orientationOfB, alpha, AB, BT, T(1), CBL);
     }
     else
     {
         auto CTR = C(indTL,indBR);
-        Gemm( NORMAL, orientationOfB, alpha, AT, BB, T(1), CTR );
+        Gemm(NORMAL, orientationOfB, alpha, AT, BB, T(1), CTR);
     }
 
     // TODO(poulson): Avoid the temporary copy
     Matrix<T> DTL;
-    Gemm( NORMAL, orientationOfB, alpha, AT, BT, DTL );
-    AxpyTrapezoid( uplo, T(1), DTL, CTL );
+    Gemm(NORMAL, orientationOfB, alpha, AT, BT, DTL);
+    AxpyTrapezoid(uplo, T(1), DTL, CTL);
 
     // TODO(poulson): Avoid the temporary copy
     Matrix<T> DBR;
-    Gemm( NORMAL, orientationOfB, alpha, AB, BB, DBR );
-    AxpyTrapezoid( uplo, T(1), DBR, CBR );
+    Gemm(NORMAL, orientationOfB, alpha, AB, BB, DBR);
+    AxpyTrapezoid(uplo, T(1), DBR, CBR);
 }
 
 // Distributed C := alpha A B^{T/H} + C
 template<typename T>
 void LocalTrrkKernel
-( UpperOrLower uplo,
+(UpperOrLower uplo,
   Orientation orientationOfB,
   T alpha, const DistMatrix<T,MC,STAR>& A,
            const DistMatrix<T,MR,STAR>& B,
-                 DistMatrix<T>& C )
+                 DistMatrix<T>& C)
 {
     EL_DEBUG_CSE
-    EL_DEBUG_ONLY(CheckInput( A, B, C ))
+    EL_DEBUG_ONLY(CheckInput(A, B, C))
     const Grid& g = C.Grid();
 
     const Int half = C.Height()/2;
@@ -278,40 +278,40 @@ void LocalTrrkKernel
     auto CTL = C(indTL,indTL);
     auto CBR = C(indBR,indBR);
 
-    if( uplo == LOWER )
+    if (uplo == LOWER)
     {
         auto CBL = C(indBR,indTL);
-        LocalGemm( NORMAL, orientationOfB, alpha, AB, BT, T(1), CBL );
+        LocalGemm(NORMAL, orientationOfB, alpha, AB, BT, T(1), CBL);
     }
     else
     {
         auto CTR = C(indTL,indBR);
-        LocalGemm( NORMAL, orientationOfB, alpha, AT, BB, T(1), CTR );
+        LocalGemm(NORMAL, orientationOfB, alpha, AT, BB, T(1), CTR);
     }
 
     // TODO(poulson): Avoid the temporary copy
     DistMatrix<T> DTL(g);
-    DTL.AlignWith( CTL );
-    LocalGemm( NORMAL, orientationOfB, alpha, AT, BT, DTL );
-    LocalAxpyTrapezoid( uplo, T(1), DTL, CTL );
+    DTL.AlignWith(CTL);
+    LocalGemm(NORMAL, orientationOfB, alpha, AT, BT, DTL);
+    LocalAxpyTrapezoid(uplo, T(1), DTL, CTL);
 
     // TODO(poulson): Avoid the temporary copy
     DistMatrix<T> DBR(g);
-    DBR.AlignWith( CBR );
-    LocalGemm( NORMAL, orientationOfB, alpha, AB, BB, DBR );
-    LocalAxpyTrapezoid( uplo, T(1), DBR, CBR );
+    DBR.AlignWith(CBR);
+    LocalGemm(NORMAL, orientationOfB, alpha, AB, BB, DBR);
+    LocalAxpyTrapezoid(uplo, T(1), DBR, CBR);
 }
 
 // Local C := alpha A^{T/H} B + C
 template<typename T>
 void TrrkTNKernel
-( UpperOrLower uplo,
+(UpperOrLower uplo,
   Orientation orientationOfA,
   T alpha, const Matrix<T>& A, const Matrix<T>& B,
-                 Matrix<T>& C )
+                 Matrix<T>& C)
 {
     EL_DEBUG_CSE
-    EL_DEBUG_ONLY(CheckInputTN( orientationOfA, A, B, C ))
+    EL_DEBUG_ONLY(CheckInputTN(orientationOfA, A, B, C))
 
     const Int half = C.Height()/2;
     const auto indTL = IR(0,half);
@@ -324,39 +324,39 @@ void TrrkTNKernel
     auto CTL = C(indTL,indTL);
     auto CBR = C(indBR,indBR);
 
-    if( uplo == LOWER )
+    if (uplo == LOWER)
     {
         auto CBL = C(indBR,indTL);
-        Gemm( orientationOfA, NORMAL, alpha, AR, BL, T(1), CBL );
+        Gemm(orientationOfA, NORMAL, alpha, AR, BL, T(1), CBL);
     }
     else
     {
         auto CTR = C(indTL,indBR);
-        Gemm( orientationOfA, NORMAL, alpha, AL, BR, T(1), CTR );
+        Gemm(orientationOfA, NORMAL, alpha, AL, BR, T(1), CTR);
     }
 
     // TODO(poulson): Avoid the temporary copy
     Matrix<T> DTL;
-    Gemm( orientationOfA, NORMAL, alpha, AL, BL, DTL );
-    AxpyTrapezoid( uplo, T(1), DTL, CTL );
+    Gemm(orientationOfA, NORMAL, alpha, AL, BL, DTL);
+    AxpyTrapezoid(uplo, T(1), DTL, CTL);
 
     // TODO(poulson): Avoid the temporary copy
     Matrix<T> DBR;
-    Gemm( orientationOfA, NORMAL, alpha, AR, BR, DBR );
-    AxpyTrapezoid( uplo, T(1), DBR, CBR );
+    Gemm(orientationOfA, NORMAL, alpha, AR, BR, DBR);
+    AxpyTrapezoid(uplo, T(1), DBR, CBR);
 }
 
 // Distributed C := alpha A^{T/H} B + C
 template<typename T>
 void LocalTrrkKernel
-( UpperOrLower uplo,
+(UpperOrLower uplo,
   Orientation orientationOfA,
   T alpha, const DistMatrix<T,STAR,MC>& A,
            const DistMatrix<T,STAR,MR>& B,
-                 DistMatrix<T>& C )
+                 DistMatrix<T>& C)
 {
     EL_DEBUG_CSE
-    EL_DEBUG_ONLY(CheckInput( A, B, C ))
+    EL_DEBUG_ONLY(CheckInput(A, B, C))
     const Grid& g = C.Grid();
 
     const Int half = C.Height()/2;
@@ -370,41 +370,41 @@ void LocalTrrkKernel
     auto CTL = C(indTL,indTL);
     auto CBR = C(indBR,indBR);
 
-    if( uplo == LOWER )
+    if (uplo == LOWER)
     {
         auto CBL = C(indBR,indTL);
-        LocalGemm( orientationOfA, NORMAL, alpha, AR, BL, T(1), CBL );
+        LocalGemm(orientationOfA, NORMAL, alpha, AR, BL, T(1), CBL);
     }
     else
     {
         auto CTR = C(indTL,indBR);
-        LocalGemm( orientationOfA, NORMAL, alpha, AL, BR, T(1), CTR );
+        LocalGemm(orientationOfA, NORMAL, alpha, AL, BR, T(1), CTR);
     }
 
     // TODO(poulson): Avoid the temporary copy
     DistMatrix<T> DTL(g);
-    DTL.AlignWith( CTL );
-    LocalGemm( orientationOfA, NORMAL, alpha, AL, BL, DTL );
-    LocalAxpyTrapezoid( uplo, T(1), DTL, CTL );
+    DTL.AlignWith(CTL);
+    LocalGemm(orientationOfA, NORMAL, alpha, AL, BL, DTL);
+    LocalAxpyTrapezoid(uplo, T(1), DTL, CTL);
 
     // TODO(poulson): Avoid the temporary copy
     DistMatrix<T> DBR(g);
-    DBR.AlignWith( CBR );
-    LocalGemm( orientationOfA, NORMAL, alpha, AR, BR, DBR );
-    LocalAxpyTrapezoid( uplo, T(1), DBR, CBR );
+    DBR.AlignWith(CBR);
+    LocalGemm(orientationOfA, NORMAL, alpha, AR, BR, DBR);
+    LocalAxpyTrapezoid(uplo, T(1), DBR, CBR);
 }
 
 // Local C := alpha A^{T/H} B^{T/H} + C
 template<typename T>
 void TrrkTTKernel
-( UpperOrLower uplo,
+(UpperOrLower uplo,
   Orientation orientationOfA,
   Orientation orientationOfB,
   T alpha, const Matrix<T>& A, const Matrix<T>& B,
-                 Matrix<T>& C )
+                 Matrix<T>& C)
 {
     EL_DEBUG_CSE
-    EL_DEBUG_ONLY(CheckInputTT( orientationOfA, orientationOfB, A, B, C ))
+    EL_DEBUG_ONLY(CheckInputTT(orientationOfA, orientationOfB, A, B, C))
 
     const Int half = C.Height()/2;
     const auto indTL = IR(0,half);
@@ -417,40 +417,40 @@ void TrrkTTKernel
     auto CTL = C(indTL,indTL);
     auto CBR = C(indBR,indBR);
 
-    if( uplo == LOWER )
+    if (uplo == LOWER)
     {
         auto CBL = C(indBR,indTL);
-        Gemm( orientationOfA, orientationOfB, alpha, AR, BT, T(1), CBL );
+        Gemm(orientationOfA, orientationOfB, alpha, AR, BT, T(1), CBL);
     }
     else
     {
         auto CTR = C(indTL,indBR);
-        Gemm( orientationOfA, orientationOfB, alpha, AL, BB, T(1), CTR );
+        Gemm(orientationOfA, orientationOfB, alpha, AL, BB, T(1), CTR);
     }
 
     // TODO(poulson): Avoid the temporary copy
     Matrix<T> DTL;
-    Gemm( orientationOfA, orientationOfB, alpha, AL, BT, DTL );
-    AxpyTrapezoid( uplo, T(1), DTL, CTL );
+    Gemm(orientationOfA, orientationOfB, alpha, AL, BT, DTL);
+    AxpyTrapezoid(uplo, T(1), DTL, CTL);
 
     // TODO(poulson): Avoid the temporary copy
     Matrix<T> DBR;
-    Gemm( orientationOfA, orientationOfB, alpha, AR, BB, DBR );
-    AxpyTrapezoid( uplo, T(1), DBR, CBR );
+    Gemm(orientationOfA, orientationOfB, alpha, AR, BB, DBR);
+    AxpyTrapezoid(uplo, T(1), DBR, CBR);
 }
 
 // Distributed C := alpha A^{T/H} B^{T/H} + C
 template<typename T>
 void LocalTrrkKernel
-( UpperOrLower uplo,
+(UpperOrLower uplo,
   Orientation orientationOfA,
   Orientation orientationOfB,
   T alpha, const DistMatrix<T,STAR,MC  >& A,
            const DistMatrix<T,MR,  STAR>& B,
-                 DistMatrix<T>& C )
+                 DistMatrix<T>& C)
 {
     EL_DEBUG_CSE
-    EL_DEBUG_ONLY(CheckInput( A, B, C ))
+    EL_DEBUG_ONLY(CheckInput(A, B, C))
     const Grid& g = C.Grid();
 
     const Int half = C.Height()/2;
@@ -464,43 +464,43 @@ void LocalTrrkKernel
     auto CTL = C(indTL,indTL);
     auto CBR = C(indBR,indBR);
 
-    if( uplo == LOWER )
+    if (uplo == LOWER)
     {
         auto CBL = C(indBR,indTL);
-        LocalGemm( orientationOfA, orientationOfB, alpha, AR, BT, T(1), CBL );
+        LocalGemm(orientationOfA, orientationOfB, alpha, AR, BT, T(1), CBL);
     }
     else
     {
         auto CTR = C(indTL,indBR);
-        LocalGemm( orientationOfA, orientationOfB, alpha, AL, BB, T(1), CTR );
+        LocalGemm(orientationOfA, orientationOfB, alpha, AL, BB, T(1), CTR);
     }
 
     // TODO(poulson): Avoid the temporary copy
     DistMatrix<T> DTL(g);
-    DTL.AlignWith( CTL );
-    LocalGemm( orientationOfA, orientationOfB, alpha, AL, BT, DTL );
-    LocalAxpyTrapezoid( uplo, T(1), DTL, CTL );
+    DTL.AlignWith(CTL);
+    LocalGemm(orientationOfA, orientationOfB, alpha, AL, BT, DTL);
+    LocalAxpyTrapezoid(uplo, T(1), DTL, CTL);
 
     // TODO(poulson): Avoid the temporary copy
     DistMatrix<T> DBR(g);
-    DBR.AlignWith( CBR );
-    LocalGemm( orientationOfA, orientationOfB, alpha, AR, BB, DBR );
-    LocalAxpyTrapezoid( uplo, T(1), DBR, CBR );
+    DBR.AlignWith(CBR);
+    LocalGemm(orientationOfA, orientationOfB, alpha, AR, BB, DBR);
+    LocalAxpyTrapezoid(uplo, T(1), DBR, CBR);
 }
 
 // Local C := alpha A B + C
 template<typename T>
 void TrrkNN
-( UpperOrLower uplo,
+(UpperOrLower uplo,
   T alpha, const Matrix<T>& A, const Matrix<T>& B,
-                 Matrix<T>& C )
+                 Matrix<T>& C)
 {
     EL_DEBUG_CSE
     using namespace trrk;
-    EL_DEBUG_ONLY(CheckInputNN( A, B, C ))
-    if( C.Height() < LocalTrrkBlocksize<T>() )
+    EL_DEBUG_ONLY(CheckInputNN(A, B, C))
+    if (C.Height() < LocalTrrkBlocksize<T>())
     {
-        TrrkNNKernel( uplo, alpha, A, B, C );
+        TrrkNNKernel(uplo, alpha, A, B, C);
     }
     else
     {
@@ -517,37 +517,37 @@ void TrrkNN
         auto CTL = C(indTL,indTL);
         auto CBR = C(indBR,indBR);
 
-        if( uplo == LOWER )
+        if (uplo == LOWER)
         {
             auto CBL = C(indBR,indTL);
-            Gemm( NORMAL, NORMAL, alpha, AB, BL, T(1), CBL );
+            Gemm(NORMAL, NORMAL, alpha, AB, BL, T(1), CBL);
         }
         else
         {
             auto CTR = C(indTL,indBR);
-            Gemm( NORMAL, NORMAL, alpha, AT, BR, T(1), CTR );
+            Gemm(NORMAL, NORMAL, alpha, AT, BR, T(1), CTR);
         }
 
         // Recurse
-        TrrkNN( uplo, alpha, AT, BL, CTL );
-        TrrkNN( uplo, alpha, AB, BR, CBR );
+        TrrkNN(uplo, alpha, AT, BL, CTL);
+        TrrkNN(uplo, alpha, AB, BR, CBR);
     }
 }
 
 // Local C := alpha A B^{T/H} + C
 template<typename T>
 void TrrkNT
-( UpperOrLower uplo,
+(UpperOrLower uplo,
   Orientation orientationOfB,
   T alpha, const Matrix<T>& A, const Matrix<T>& B,
-                 Matrix<T>& C )
+                 Matrix<T>& C)
 {
     EL_DEBUG_CSE
     using namespace trrk;
-    EL_DEBUG_ONLY(CheckInputNT( orientationOfB, A, B, C ))
-    if( C.Height() < LocalTrrkBlocksize<T>() )
+    EL_DEBUG_ONLY(CheckInputNT(orientationOfB, A, B, C))
+    if (C.Height() < LocalTrrkBlocksize<T>())
     {
-        TrrkNTKernel( uplo, orientationOfB, alpha, A, B, C );
+        TrrkNTKernel(uplo, orientationOfB, alpha, A, B, C);
     }
     else
     {
@@ -564,37 +564,37 @@ void TrrkNT
         auto CTL = C(indTL,indTL);
         auto CBR = C(indBR,indBR);
 
-        if( uplo == LOWER )
+        if (uplo == LOWER)
         {
             auto CBL = C(indBR,indTL);
-            Gemm( NORMAL, orientationOfB, alpha, AB, BT, T(1), CBL );
+            Gemm(NORMAL, orientationOfB, alpha, AB, BT, T(1), CBL);
         }
         else
         {
             auto CTR = C(indTL,indBR);
-            Gemm( NORMAL, orientationOfB, alpha, AT, BB, T(1), CTR );
+            Gemm(NORMAL, orientationOfB, alpha, AT, BB, T(1), CTR);
         }
 
         // Recurse
-        TrrkNT( uplo, orientationOfB, alpha, AT, BT, CTL );
-        TrrkNT( uplo, orientationOfB, alpha, AB, BB, CBR );
+        TrrkNT(uplo, orientationOfB, alpha, AT, BT, CTL);
+        TrrkNT(uplo, orientationOfB, alpha, AB, BB, CBR);
     }
 }
 
 // Local C := alpha A^{T/H} B + C
 template<typename T>
 void TrrkTN
-( UpperOrLower uplo,
+(UpperOrLower uplo,
   Orientation orientationOfA,
   T alpha, const Matrix<T>& A, const Matrix<T>& B,
-                 Matrix<T>& C )
+                 Matrix<T>& C)
 {
     EL_DEBUG_CSE
     using namespace trrk;
-    EL_DEBUG_ONLY(CheckInputTN( orientationOfA, A, B, C ))
-    if( C.Height() < LocalTrrkBlocksize<T>() )
+    EL_DEBUG_ONLY(CheckInputTN(orientationOfA, A, B, C))
+    if (C.Height() < LocalTrrkBlocksize<T>())
     {
-        TrrkTNKernel( uplo, orientationOfA, alpha, A, B, C );
+        TrrkTNKernel(uplo, orientationOfA, alpha, A, B, C);
     }
     else
     {
@@ -611,37 +611,37 @@ void TrrkTN
         auto CTL = C(indTL,indTL);
         auto CBR = C(indBR,indBR);
 
-        if( uplo == LOWER )
+        if (uplo == LOWER)
         {
             auto CBL = C(indBR,indTL);
-            Gemm( orientationOfA, NORMAL, alpha, AR, BL, T(1), CBL );
+            Gemm(orientationOfA, NORMAL, alpha, AR, BL, T(1), CBL);
         }
         else
         {
             auto CTR = C(indTL,indBR);
-            Gemm( orientationOfA, NORMAL, alpha, AL, BR, T(1), CTR );
+            Gemm(orientationOfA, NORMAL, alpha, AL, BR, T(1), CTR);
         }
 
         // Recurse
-        TrrkTN( uplo, orientationOfA, alpha, AL, BL, CTL );
-        TrrkTN( uplo, orientationOfA, alpha, AR, BR, CBR );
+        TrrkTN(uplo, orientationOfA, alpha, AL, BL, CTL);
+        TrrkTN(uplo, orientationOfA, alpha, AR, BR, CBR);
     }
 }
 
 // Local C := alpha A^{T/H} B^{T/H} + C
 template<typename T>
 void TrrkTT
-( UpperOrLower uplo,
+(UpperOrLower uplo,
   Orientation orientationOfA, Orientation orientationOfB,
   T alpha, const Matrix<T>& A, const Matrix<T>& B,
-                 Matrix<T>& C )
+                 Matrix<T>& C)
 {
     EL_DEBUG_CSE
     using namespace trrk;
-    EL_DEBUG_ONLY(CheckInputTT( orientationOfA, orientationOfB, A, B, C ))
-    if( C.Height() < LocalTrrkBlocksize<T>() )
+    EL_DEBUG_ONLY(CheckInputTT(orientationOfA, orientationOfB, A, B, C))
+    if (C.Height() < LocalTrrkBlocksize<T>())
     {
-        TrrkTTKernel( uplo, orientationOfA, orientationOfB, alpha, A, B, C );
+        TrrkTTKernel(uplo, orientationOfA, orientationOfB, alpha, A, B, C);
     }
     else
     {
@@ -658,20 +658,20 @@ void TrrkTT
         auto CTL = C(indTL,indTL);
         auto CBR = C(indBR,indBR);
 
-        if( uplo == LOWER )
+        if (uplo == LOWER)
         {
             auto CBL = C(indBR,indTL);
-            Gemm( orientationOfA, orientationOfB, alpha, AR, BT, T(1), CBL );
+            Gemm(orientationOfA, orientationOfB, alpha, AR, BT, T(1), CBL);
         }
         else
         {
             auto CTR = C(indTL,indBR);
-            Gemm( orientationOfA, orientationOfB, alpha, AL, BB, T(1), CTR );
+            Gemm(orientationOfA, orientationOfB, alpha, AL, BB, T(1), CTR);
         }
 
         // Recurse
-        TrrkTT( uplo, orientationOfA, orientationOfB, alpha, AL, BT, CTL );
-        TrrkTT( uplo, orientationOfA, orientationOfB, alpha, AR, BB, CBR );
+        TrrkTT(uplo, orientationOfA, orientationOfB, alpha, AL, BT, CTL);
+        TrrkTT(uplo, orientationOfA, orientationOfB, alpha, AR, BB, CBR);
     }
 }
 
@@ -680,20 +680,20 @@ void TrrkTT
 // Distributed C := alpha A B + beta C
 template<typename T>
 void LocalTrrk
-( UpperOrLower uplo,
+(UpperOrLower uplo,
   T alpha, const DistMatrix<T,MC,  STAR>& A,
            const DistMatrix<T,STAR,MR  >& B,
-  T beta,        DistMatrix<T>& C )
+  T beta,        DistMatrix<T>& C)
 {
     EL_DEBUG_CSE
     using namespace trrk;
-    EL_DEBUG_ONLY(CheckInput( A, B, C ))
+    EL_DEBUG_ONLY(CheckInput(A, B, C))
     const Grid& g = C.Grid();
-    ScaleTrapezoid( beta, uplo, C );
+    ScaleTrapezoid(beta, uplo, C);
 
-    if( C.Height() < g.Width()*LocalTrrkBlocksize<T>() )
+    if (C.Height() < g.Width()*LocalTrrkBlocksize<T>())
     {
-        LocalTrrkKernel( uplo, alpha, A, B, C );
+        LocalTrrkKernel(uplo, alpha, A, B, C);
     }
     else
     {
@@ -710,41 +710,41 @@ void LocalTrrk
         auto CTL = C(indTL,indTL);
         auto CBR = C(indBR,indBR);
 
-        if( uplo == LOWER )
+        if (uplo == LOWER)
         {
             auto CBL = C(indBR,indTL);
-            LocalGemm( NORMAL, NORMAL, alpha, AB, BL, T(1), CBL );
+            LocalGemm(NORMAL, NORMAL, alpha, AB, BL, T(1), CBL);
         }
         else
         {
             auto CTR = C(indTL,indBR);
-            LocalGemm( NORMAL, NORMAL, alpha, AT, BR, T(1), CTR );
+            LocalGemm(NORMAL, NORMAL, alpha, AT, BR, T(1), CTR);
         }
 
         // Recurse
-        LocalTrrk( uplo, alpha, AT, BL, T(1), CTL );
-        LocalTrrk( uplo, alpha, AB, BR, T(1), CBR );
+        LocalTrrk(uplo, alpha, AT, BL, T(1), CTL);
+        LocalTrrk(uplo, alpha, AB, BR, T(1), CBR);
     }
 }
 
 // Distributed C := alpha A B^{T/H} + beta C
 template<typename T>
 void LocalTrrk
-( UpperOrLower uplo,
+(UpperOrLower uplo,
   Orientation orientationOfB,
   T alpha, const DistMatrix<T,MC,STAR>& A,
            const DistMatrix<T,MR,STAR>& B,
-  T beta,        DistMatrix<T>& C )
+  T beta,        DistMatrix<T>& C)
 {
     EL_DEBUG_CSE
     using namespace trrk;
-    EL_DEBUG_ONLY(CheckInput( A, B, C ))
+    EL_DEBUG_ONLY(CheckInput(A, B, C))
     const Grid& g = C.Grid();
-    ScaleTrapezoid( beta, uplo, C );
+    ScaleTrapezoid(beta, uplo, C);
 
-    if( C.Height() < g.Width()*LocalTrrkBlocksize<T>() )
+    if (C.Height() < g.Width()*LocalTrrkBlocksize<T>())
     {
-        LocalTrrkKernel( uplo, orientationOfB, alpha, A, B, C );
+        LocalTrrkKernel(uplo, orientationOfB, alpha, A, B, C);
     }
     else
     {
@@ -761,41 +761,41 @@ void LocalTrrk
         auto CTL = C(indTL,indTL);
         auto CBR = C(indBR,indBR);
 
-        if( uplo == LOWER )
+        if (uplo == LOWER)
         {
             auto CBL = C(indBR,indTL);
-            LocalGemm( NORMAL, orientationOfB, alpha, AB, BT, T(1), CBL );
+            LocalGemm(NORMAL, orientationOfB, alpha, AB, BT, T(1), CBL);
         }
         else
         {
             auto CTR = C(indTL,indBR);
-            LocalGemm( NORMAL, orientationOfB, alpha, AT, BB, T(1), CTR );
+            LocalGemm(NORMAL, orientationOfB, alpha, AT, BB, T(1), CTR);
         }
 
         // Recurse
-        LocalTrrk( uplo, orientationOfB, alpha, AT, BT, T(1), CTL );
-        LocalTrrk( uplo, orientationOfB, alpha, AB, BB, T(1), CBR );
+        LocalTrrk(uplo, orientationOfB, alpha, AT, BT, T(1), CTL);
+        LocalTrrk(uplo, orientationOfB, alpha, AB, BB, T(1), CBR);
     }
 }
 
 // Distributed C := alpha A^{T/H} B + beta C
 template<typename T>
 void LocalTrrk
-( UpperOrLower uplo,
+(UpperOrLower uplo,
   Orientation orientationOfA,
   T alpha, const DistMatrix<T,STAR,MC>& A,
            const DistMatrix<T,STAR,MR>& B,
-  T beta,        DistMatrix<T>& C )
+  T beta,        DistMatrix<T>& C)
 {
     EL_DEBUG_CSE
     using namespace trrk;
-    EL_DEBUG_ONLY(CheckInput( A, B, C ))
+    EL_DEBUG_ONLY(CheckInput(A, B, C))
     const Grid& g = C.Grid();
-    ScaleTrapezoid( beta, uplo, C );
+    ScaleTrapezoid(beta, uplo, C);
 
-    if( C.Height() < g.Width()*LocalTrrkBlocksize<T>() )
+    if (C.Height() < g.Width()*LocalTrrkBlocksize<T>())
     {
-        LocalTrrkKernel( uplo, orientationOfA, alpha, A, B, C );
+        LocalTrrkKernel(uplo, orientationOfA, alpha, A, B, C);
     }
     else
     {
@@ -812,41 +812,41 @@ void LocalTrrk
         auto CTL = C(indTL,indTL);
         auto CBR = C(indBR,indBR);
 
-        if( uplo == LOWER )
+        if (uplo == LOWER)
         {
             auto CBL = C(indBR,indTL);
-            LocalGemm( orientationOfA, NORMAL, alpha, AR, BL, T(1), CBL );
+            LocalGemm(orientationOfA, NORMAL, alpha, AR, BL, T(1), CBL);
         }
         else
         {
             auto CTR = C(indTL,indBR);
-            LocalGemm( orientationOfA, NORMAL, alpha, AL, BR, T(1), CTR );
+            LocalGemm(orientationOfA, NORMAL, alpha, AL, BR, T(1), CTR);
         }
 
         // Recurse
-        LocalTrrk( uplo, orientationOfA, alpha, AL, BL, T(1), CTL );
-        LocalTrrk( uplo, orientationOfA, alpha, AR, BR, T(1), CBR );
+        LocalTrrk(uplo, orientationOfA, alpha, AL, BL, T(1), CTL);
+        LocalTrrk(uplo, orientationOfA, alpha, AR, BR, T(1), CBR);
     }
 }
 
 // Distributed C := alpha A^{T/H} B^{T/H} + beta C
 template<typename T>
 void LocalTrrk
-( UpperOrLower uplo,
+(UpperOrLower uplo,
   Orientation orientationOfA, Orientation orientationOfB,
   T alpha, const DistMatrix<T,STAR,MC  >& A,
            const DistMatrix<T,MR,  STAR>& B,
-  T beta,        DistMatrix<T>& C )
+  T beta,        DistMatrix<T>& C)
 {
     EL_DEBUG_CSE
     using namespace trrk;
-    EL_DEBUG_ONLY(CheckInput( A, B, C ))
+    EL_DEBUG_ONLY(CheckInput(A, B, C))
     const Grid& g = C.Grid();
-    ScaleTrapezoid( beta, uplo, C );
+    ScaleTrapezoid(beta, uplo, C);
 
-    if( C.Height() < g.Width()*LocalTrrkBlocksize<T>() )
+    if (C.Height() < g.Width()*LocalTrrkBlocksize<T>())
     {
-        LocalTrrkKernel( uplo, orientationOfA, orientationOfB, alpha, A, B, C );
+        LocalTrrkKernel(uplo, orientationOfA, orientationOfB, alpha, A, B, C);
     }
     else
     {
@@ -863,24 +863,24 @@ void LocalTrrk
         auto CTL = C(indTL,indTL);
         auto CBR = C(indBR,indBR);
 
-        if( uplo == LOWER )
+        if (uplo == LOWER)
         {
             auto CBL = C(indBR,indTL);
             LocalGemm
-            ( orientationOfA, orientationOfB, alpha, AR, BT, T(1), CBL );
+            (orientationOfA, orientationOfB, alpha, AR, BT, T(1), CBL);
         }
         else
         {
             auto CTR = C(indTL,indBR);
             LocalGemm
-            ( orientationOfA, orientationOfB, alpha, AL, BB, T(1), CTR );
+            (orientationOfA, orientationOfB, alpha, AL, BB, T(1), CTR);
         }
 
         // Recurse
         LocalTrrk
-        ( uplo, orientationOfA, orientationOfB, alpha, AL, BT, T(1), CTL );
+        (uplo, orientationOfA, orientationOfB, alpha, AL, BT, T(1), CTL);
         LocalTrrk
-        ( uplo, orientationOfA, orientationOfB, alpha, AR, BB, T(1), CBR );
+        (uplo, orientationOfA, orientationOfB, alpha, AR, BB, T(1), CBR);
     }
 }
 

--- a/src/blas_like/level3/Trsm.cpp
+++ b/src/blas_like/level3/Trsm.cpp
@@ -34,7 +34,7 @@ void Trsm(
     Matrix<F, Device::GPU>& B,
     bool const)
 {
-    auto SyncManager = MakeMultiSync(
+    auto multisync = MakeMultiSync(
         SyncInfoFromMatrix(B), SyncInfoFromMatrix(A));
 
     gpu_blas::Trsm(
@@ -44,7 +44,7 @@ void Trsm(
         A.Height(), A.Width(),
         alpha, A.LockedBuffer(), A.LDim(),
         B.Buffer(), B.LDim(),
-        SyncManager);
+        multisync);
 }
 #endif // HYDROGEN_HAVE_GPU
 

--- a/src/blas_like/level3/Trsm.cpp
+++ b/src/blas_like/level3/Trsm.cpp
@@ -32,9 +32,19 @@ void Trsm(
     F alpha,
     Matrix<F, Device::GPU> const& A,
     Matrix<F, Device::GPU>& B,
-    bool checkIfSingular)
+    bool const)
 {
-    RuntimeError("GPU impl not done yet.");
+    auto SyncManager = MakeMultiSync(
+        SyncInfoFromMatrix(B), SyncInfoFromMatrix(A));
+
+    gpu_blas::Trsm(
+        LeftOrRightToSideMode(side), UpperOrLowerToFillMode(uplo),
+        OrientationToTransposeMode(orientation),
+        UnitOrNonUnitToDiagType(diag),
+        A.Height(), A.Width(),
+        alpha, A.LockedBuffer(), A.LDim(),
+        B.Buffer(), B.LDim(),
+        SyncManager);
 }
 #endif // HYDROGEN_HAVE_GPU
 
@@ -49,35 +59,21 @@ void Trsm(
     Matrix<F>& B,
     bool checkIfSingular)
 {
-    EL_DEBUG_CSE
-    EL_DEBUG_ONLY(
-      if( A.Height() != A.Width() )
-          LogicError("Triangular matrix must be square");
-      if( side == LEFT )
-      {
-          if( A.Height() != B.Height() )
-              LogicError("Nonconformal Trsm");
-      }
-      else
-      {
-          if( A.Height() != B.Width() )
-              LogicError("Nonconformal Trsm");
-      }
-    )
-    const char sideChar = LeftOrRightToChar( side );
-    const char uploChar = UpperOrLowerToChar( uplo );
-    const char transChar = OrientationToChar( orientation );
-    const char diagChar = UnitOrNonUnitToChar( diag );
-    if( checkIfSingular && diag != UNIT )
+    if (checkIfSingular && diag != UNIT)
     {
         const Int n = A.Height();
-        for( Int j=0; j<n; ++j )
-            if( A.Get(j,j) == F(0) )
+        for (Int j=0; j<n; ++j)
+            if (A.Get(j,j) == F(0))
                 throw SingularMatrixException();
     }
-    blas::Trsm
-    ( sideChar, uploChar, transChar, diagChar, B.Height(), B.Width(),
-      alpha, A.LockedBuffer(), A.LDim(), B.Buffer(), B.LDim() );
+    const char sideChar = LeftOrRightToChar(side);
+    const char uploChar = UpperOrLowerToChar(uplo);
+    const char transChar = OrientationToChar(orientation);
+    const char diagChar = UnitOrNonUnitToChar(diag);
+    blas::Trsm(
+        sideChar, uploChar, transChar, diagChar,
+        B.Height(), B.Width(),
+        alpha, A.LockedBuffer(), A.LDim(), B.Buffer(), B.LDim());
 }
 
 template <typename F>
@@ -91,6 +87,22 @@ void Trsm(
     AbstractMatrix<F>& B,
     bool checkIfSingular)
 {
+    EL_DEBUG_CSE;
+#ifndef EL_RELEASE
+    if (A.Height() != A.Width())
+        LogicError("Triangular matrix must be square");
+    if (side == LEFT)
+    {
+        if (A.Height() != B.Height())
+            LogicError("Nonconformal Trsm");
+    }
+    else
+    {
+        if (A.Height() != B.Width())
+            LogicError("Nonconformal Trsm");
+    }
+#endif // EL_RELEASE
+
     switch (A.GetDevice())
     {
     case Device::CPU:
@@ -453,8 +465,8 @@ void LocalTrsm
     Orientation orientation, \
     UnitOrNonUnit diag, \
     F alpha, \
-    const Matrix<F>& A, \
-          Matrix<F>& B, \
+    AbstractMatrix<F> const& A, \
+    AbstractMatrix<F>& B,       \
     bool checkIfSingular ); \
   template void Trsm \
   ( LeftOrRight side, \

--- a/src/core/imports/blas/Syr.hpp
+++ b/src/core/imports/blas/Syr.hpp
@@ -92,6 +92,13 @@ template void Her
   const Int& alpha,
   const Int* x, BlasInt incx,
         Int* A, BlasInt ALDim );
+#ifdef HYDROGEN_HAVE_HALF
+template void Her(
+    char uplo, BlasInt m,
+    cpu_half_type const& alpha,
+    cpu_half_type const* x, BlasInt incx,
+    cpu_half_type* A, BlasInt ALDim);
+#endif // HYDROGEN_HAVE_HALF
 #ifdef HYDROGEN_HAVE_QD
 template void Her
 ( char uplo, BlasInt m,

--- a/src/core/imports/blas/Syrk.hpp
+++ b/src/core/imports/blas/Syrk.hpp
@@ -2,8 +2,8 @@
    Copyright (c) 2009-2016, Jack Poulson
    All rights reserved.
 
-   This file is part of Elemental and is under the BSD 2-Clause License, 
-   which can be found in the LICENSE file in the root directory, or at 
+   This file is part of Elemental and is under the BSD 2-Clause License,
+   which can be found in the LICENSE file in the root directory, or at
    http://opensource.org/licenses/BSD-2-Clause
 */
 
@@ -170,6 +170,14 @@ template void Herk
   const Int* A, BlasInt ALDim,
   const Int& beta,
         Int* C, BlasInt CLDim );
+#ifdef HYDROGEN_HAVE_HALF
+template void Herk(char uplo, char trans,
+                   BlasInt n, BlasInt k,
+                   cpu_half_type const& alpha,
+                   cpu_half_type const* A, BlasInt ALDim,
+                   cpu_half_type const& beta,
+                   cpu_half_type* C, BlasInt CLDim);
+#endif // HYDROGEN_HAVE_HALF
 #ifdef HYDROGEN_HAVE_QD
 template void Herk
 ( char uplo, char trans,
@@ -293,9 +301,9 @@ void Herk
 template<typename T>
 void Syrk
 ( char uplo, char trans,
-  BlasInt n, BlasInt k, 
+  BlasInt n, BlasInt k,
   const T& alpha,
-  const T* A, BlasInt ALDim, 
+  const T* A, BlasInt ALDim,
   const T& beta,
         T* C, BlasInt CLDim )
 {
@@ -401,77 +409,86 @@ void Syrk
 }
 template void Syrk
 ( char uplo, char trans,
-  BlasInt n, BlasInt k, 
+  BlasInt n, BlasInt k,
   const Int& alpha,
-  const Int* A, BlasInt ALDim, 
+  const Int* A, BlasInt ALDim,
   const Int& beta,
         Int* C, BlasInt CLDim );
+#ifdef HYDROGEN_HAVE_HALF
+template void Syrk(
+    char uplo, char trans,
+    BlasInt n, BlasInt k,
+    cpu_half_type const& alpha,
+    cpu_half_type const* A, BlasInt ALDim,
+    cpu_half_type const& beta,
+    cpu_half_type* C, BlasInt CLDim );
+#endif // HYDROGEN_HAVE_HALF
 #ifdef HYDROGEN_HAVE_QD
 template void Syrk
 ( char uplo, char trans,
-  BlasInt n, BlasInt k, 
+  BlasInt n, BlasInt k,
   const DoubleDouble& alpha,
-  const DoubleDouble* A, BlasInt ALDim, 
+  const DoubleDouble* A, BlasInt ALDim,
   const DoubleDouble& beta,
         DoubleDouble* C, BlasInt CLDim );
 template void Syrk
 ( char uplo, char trans,
-  BlasInt n, BlasInt k, 
+  BlasInt n, BlasInt k,
   const QuadDouble& alpha,
-  const QuadDouble* A, BlasInt ALDim, 
+  const QuadDouble* A, BlasInt ALDim,
   const QuadDouble& beta,
         QuadDouble* C, BlasInt CLDim );
 template void Syrk
 ( char uplo, char trans,
-  BlasInt n, BlasInt k, 
+  BlasInt n, BlasInt k,
   const Complex<DoubleDouble>& alpha,
-  const Complex<DoubleDouble>* A, BlasInt ALDim, 
+  const Complex<DoubleDouble>* A, BlasInt ALDim,
   const Complex<DoubleDouble>& beta,
         Complex<DoubleDouble>* C, BlasInt CLDim );
 template void Syrk
 ( char uplo, char trans,
-  BlasInt n, BlasInt k, 
+  BlasInt n, BlasInt k,
   const Complex<QuadDouble>& alpha,
-  const Complex<QuadDouble>* A, BlasInt ALDim, 
+  const Complex<QuadDouble>* A, BlasInt ALDim,
   const Complex<QuadDouble>& beta,
         Complex<QuadDouble>* C, BlasInt CLDim );
 #endif
 #ifdef HYDROGEN_HAVE_QUADMATH
 template void Syrk
 ( char uplo, char trans,
-  BlasInt n, BlasInt k, 
+  BlasInt n, BlasInt k,
   const Quad& alpha,
-  const Quad* A, BlasInt ALDim, 
+  const Quad* A, BlasInt ALDim,
   const Quad& beta,
         Quad* C, BlasInt CLDim );
 template void Syrk
 ( char uplo, char trans,
   BlasInt n, BlasInt k,
   const Complex<Quad>& alpha,
-  const Complex<Quad>* A, BlasInt ALDim, 
+  const Complex<Quad>* A, BlasInt ALDim,
   const Complex<Quad>& beta,
         Complex<Quad>* C, BlasInt CLDim );
 #endif
 #ifdef HYDROGEN_HAVE_MPC
 template void Syrk
 ( char uplo, char trans,
-  BlasInt n, BlasInt k, 
+  BlasInt n, BlasInt k,
   const BigInt& alpha,
-  const BigInt* A, BlasInt ALDim, 
+  const BigInt* A, BlasInt ALDim,
   const BigInt& beta,
         BigInt* C, BlasInt CLDim );
 template void Syrk
 ( char uplo, char trans,
-  BlasInt n, BlasInt k, 
+  BlasInt n, BlasInt k,
   const BigFloat& alpha,
-  const BigFloat* A, BlasInt ALDim, 
+  const BigFloat* A, BlasInt ALDim,
   const BigFloat& beta,
         BigFloat* C, BlasInt CLDim );
 template void Syrk
 ( char uplo, char trans,
-  BlasInt n, BlasInt k, 
+  BlasInt n, BlasInt k,
   const Complex<BigFloat>& alpha,
-  const Complex<BigFloat>* A, BlasInt ALDim, 
+  const Complex<BigFloat>* A, BlasInt ALDim,
   const Complex<BigFloat>& beta,
         Complex<BigFloat>* C, BlasInt CLDim );
 #endif

--- a/src/core/imports/blas/Trsm.hpp
+++ b/src/core/imports/blas/Trsm.hpp
@@ -2,8 +2,8 @@
    Copyright (c) 2009-2016, Jack Poulson
    All rights reserved.
 
-   This file is part of Elemental and is under the BSD 2-Clause License, 
-   which can be found in the LICENSE file in the root directory, or at 
+   This file is part of Elemental and is under the BSD 2-Clause License,
+   which can be found in the LICENSE file in the root directory, or at
    http://opensource.org/licenses/BSD-2-Clause
 */
 
@@ -64,12 +64,12 @@ void Trsm
         {
             if( lower )
             {
-                for( BlasInt k=0; k<m; ++k )     
+                for( BlasInt k=0; k<m; ++k )
                 {
                     if( !unitDiag )
                     {
                         alpha11 = A[k+k*ALDim];
-                        for( BlasInt j=0; j<n; ++j )      
+                        for( BlasInt j=0; j<n; ++j )
                             B[k+j*BLDim] /= alpha11;
                     }
                     Geru
@@ -81,12 +81,12 @@ void Trsm
             }
             else
             {
-                for( BlasInt k=m-1; k>=0; --k )     
+                for( BlasInt k=m-1; k>=0; --k )
                 {
                     if( !unitDiag )
                     {
                         alpha11 = A[k+k*ALDim];
-                        for( BlasInt j=0; j<n; ++j )      
+                        for( BlasInt j=0; j<n; ++j )
                             B[k+j*BLDim] /= alpha11;
                     }
                     Geru
@@ -293,6 +293,14 @@ void Trsm
         }
     }
 }
+#ifdef HYDROGEN_HAVE_HALF
+template void Trsm(
+    char side, char uplo, char trans, char unit,
+    BlasInt m, BlasInt n,
+    cpu_half_type const& alpha,
+    cpu_half_type const* A, BlasInt ALDim,
+    cpu_half_type* B, BlasInt BLDim);
+#endif // HYDROGEN_HAVE_HALF
 #ifdef HYDROGEN_HAVE_QD
 template void Trsm
 ( char side, char uplo, char trans, char unit,
@@ -358,7 +366,7 @@ void Trsm
     const char fixedTrans = ( std::toupper(trans) == 'C' ? 'T' : trans );
     EL_BLAS(strsm)
     ( &side, &uplo, &fixedTrans, &unit, &m, &n, &alpha, A, &ALDim, B, &BLDim );
-} 
+}
 
 void Trsm
 ( char side, char uplo, char trans, char unit,
@@ -370,7 +378,7 @@ void Trsm
     const char fixedTrans = ( std::toupper(trans) == 'C' ? 'T' : trans );
     EL_BLAS(dtrsm)
     ( &side, &uplo, &fixedTrans, &unit, &m, &n, &alpha, A, &ALDim, B, &BLDim );
-} 
+}
 
 void Trsm
 ( char side, char uplo, char trans, char unit,
@@ -381,7 +389,7 @@ void Trsm
 {
     EL_BLAS(ctrsm)
     ( &side, &uplo, &trans, &unit, &m, &n, &alpha, A, &ALDim, B, &BLDim );
-} 
+}
 
 void Trsm
 ( char side, char uplo, char trans, char unit,
@@ -392,7 +400,7 @@ void Trsm
 {
     EL_BLAS(ztrsm)
     ( &side, &uplo, &trans, &unit, &m, &n, &alpha, A, &ALDim, B, &BLDim );
-} 
+}
 
 } // namespace blas
 } // namespace El

--- a/src/core/imports/blas/Trsv.hpp
+++ b/src/core/imports/blas/Trsv.hpp
@@ -2,8 +2,8 @@
    Copyright (c) 2009-2016, Jack Poulson
    All rights reserved.
 
-   This file is part of Elemental and is under the BSD 2-Clause License, 
-   which can be found in the LICENSE file in the root directory, or at 
+   This file is part of Elemental and is under the BSD 2-Clause License,
+   which can be found in the LICENSE file in the root directory, or at
    http://opensource.org/licenses/BSD-2-Clause
 */
 
@@ -48,7 +48,7 @@ void Trsv
         {
             for( BlasInt j=0; j<m; ++j )
             {
-                if( !unitDiag ) 
+                if( !unitDiag )
                     x[j*incx] /= A[j+j*ALDim];
                 gamma = x[j*incx];
                 for( BlasInt i=j+1; i<m; ++i )
@@ -116,7 +116,7 @@ void Trsv
             {
                 if( conj )
                 {
-                    if( !unitDiag ) 
+                    if( !unitDiag )
                     {
                         Conj( A[j+j*ALDim], delta );
                         x[j*incx] /= delta;
@@ -131,7 +131,7 @@ void Trsv
                 }
                 else
                 {
-                    if( !unitDiag ) 
+                    if( !unitDiag )
                         x[j*incx] /= A[j+j*ALDim];
                     gamma = x[j*incx];
                     for( BlasInt i=j+1; i<m; ++i )
@@ -145,6 +145,12 @@ void Trsv
         }
     }
 }
+#ifdef HYDROGEN_HAVE_HALF
+template void Trsv(
+    char uplo, char trans, char diag, BlasInt m,
+    cpu_half_type const* A, BlasInt ALDim,
+    cpu_half_type* X, BlasInt incx);
+#endif // HYDROGEN_HAVE_HALF
 #ifdef HYDROGEN_HAVE_QD
 template void Trsv
 ( char uplo, char trans, char diag, BlasInt m,

--- a/src/hydrogen/device/CMakeLists.txt
+++ b/src/hydrogen/device/CMakeLists.txt
@@ -14,6 +14,8 @@ if (HYDROGEN_HAVE_GPU)
       ROCm.cpp
       rocBLAS.cpp
       rocBLAS_API.cpp
+      rocSOLVER.cpp
+      rocSOLVER_API.cpp
       )
   endif ()
 

--- a/src/hydrogen/device/CMakeLists.txt
+++ b/src/hydrogen/device/CMakeLists.txt
@@ -4,6 +4,8 @@ if (HYDROGEN_HAVE_GPU)
       CUDA.cpp
       cuBLAS.cpp
       cuBLAS_API.cpp
+      cuSOLVER.cpp
+      cuSOLVER_API.cpp
       GPU.cpp)
   endif ()
   if (HYDROGEN_HAVE_ROCM)

--- a/src/hydrogen/device/cuBLAS.cpp
+++ b/src/hydrogen/device/cuBLAS.cpp
@@ -1,4 +1,5 @@
 #include <hydrogen/device/gpu/cuda/cuBLAS.hpp>
+#include <hydrogen/device/gpu/cuda/cuSOLVER.hpp>
 
 // Helper macro for converting enums to strings.
 #define H_ADD_CUBLAS_ENUM_TO_STRING_CASE(enum_value) \
@@ -74,6 +75,13 @@ void Initialize(cublasHandle_t handle)
 #endif // HYDROGEN_GPU_USE_TENSOR_OP_MATH
 
         cublas_is_initialized_ = true;
+
+        // At this moment in time, cuSOLVER support in Hydrogen should
+        // be viewed as inseparable from cuBLAS support. This ensures
+        // that the library gets initialized. If cuSOLVER support
+        // expands beyond the one function currently supported, we
+        // should move this somewhere people will actually see it...
+        cusolver::InitializeDense();
     }
 }
 

--- a/src/hydrogen/device/cuBLAS_API.cpp
+++ b/src/hydrogen/device/cuBLAS_API.cpp
@@ -236,6 +236,22 @@ using RealType = typename RealTypeT<T>::type;
                 &alpha, A, lda, &beta, C, ldc));        \
     }
 
+#define ADD_TRSM_IMPL(ScalarType, TypeChar)     \
+    void Trsm(                                  \
+        cublasHandle_t handle,                                \
+        cublasSideMode_t side, cublasFillMode_t uplo,         \
+        cublasOperation_t trans, cublasDiagType_t diag,       \
+        int m, int n,                                         \
+        ScalarType const& alpha,                              \
+        ScalarType const* A, int lda,                         \
+        ScalarType* B, int ldb)                               \
+    {                                                         \
+        H_CHECK_CUBLAS(                                       \
+            cublas ## TypeChar ## trsm(                       \
+                handle, side, uplo, trans, diag,              \
+                m, n, &alpha, A, lda, B, ldb));               \
+    }
+
 #define ADD_GEMM_IMPL(ScalarType, TypeChar)             \
     void Gemm(                                          \
         cublasHandle_t handle,                          \
@@ -363,6 +379,11 @@ ADD_SYRK_IMPL(float, S)
 ADD_SYRK_IMPL(double, D)
 ADD_SYRK_IMPL(cuComplex, C)
 ADD_SYRK_IMPL(cuDoubleComplex, Z)
+
+ADD_TRSM_IMPL(float, S)
+ADD_TRSM_IMPL(double, D)
+ADD_TRSM_IMPL(cuComplex, C)
+ADD_TRSM_IMPL(cuDoubleComplex, Z)
 
 ADD_GEMM_IMPL(__half, H)
 ADD_GEMM_IMPL(float, S)

--- a/src/hydrogen/device/cuBLAS_API.cpp
+++ b/src/hydrogen/device/cuBLAS_API.cpp
@@ -200,6 +200,25 @@ using RealType = typename RealTypeT<T>::type;
 //
 // BLAS 3
 //
+
+#define ADD_REAL_HERK_IMPL(ScalarType, TypeChar)        \
+    void Herk(                                          \
+        cublasHandle_t handle,                          \
+        cublasFillMode_t uplo, cublasOperation_t trans, \
+        int n, int k,                                   \
+        ScalarType const& alpha,                        \
+        ScalarType const* A, int lda,                   \
+        ScalarType const& beta,                         \
+        ScalarType * C, int ldc)                        \
+    {                                                   \
+        H_CHECK_CUBLAS(                                 \
+            cublas ## TypeChar ## syrk(                 \
+                handle,                                 \
+                uplo, trans,                            \
+                n, k,                                   \
+                &alpha, A, lda, &beta, C, ldc));        \
+    }
+
 #define ADD_HERK_IMPL(ScalarType, BaseScalarType, TypeChar)     \
     void Herk(                                                  \
         cublasHandle_t handle,                                  \
@@ -372,6 +391,8 @@ ADD_GEMV_IMPL(cuComplex, C)
 ADD_GEMV_IMPL(cuDoubleComplex, Z)
 
 // BLAS 3
+ADD_REAL_HERK_IMPL(float, S)
+ADD_REAL_HERK_IMPL(double, D)
 ADD_HERK_IMPL(cuComplex, float, C)
 ADD_HERK_IMPL(cuDoubleComplex, double, Z)
 

--- a/src/hydrogen/device/cuBLAS_API.cpp
+++ b/src/hydrogen/device/cuBLAS_API.cpp
@@ -200,6 +200,42 @@ using RealType = typename RealTypeT<T>::type;
 //
 // BLAS 3
 //
+#define ADD_HERK_IMPL(ScalarType, BaseScalarType, TypeChar)     \
+    void Herk(                                                  \
+        cublasHandle_t handle,                                  \
+        cublasFillMode_t uplo, cublasOperation_t trans,         \
+        int n, int k,                                           \
+        BaseScalarType const& alpha,                            \
+        ScalarType const* A, int lda,                           \
+        BaseScalarType const& beta,                             \
+        ScalarType * C, int ldc)                                \
+    {                                                           \
+        H_CHECK_CUBLAS(                                         \
+            cublas ## TypeChar ## herk(                         \
+                handle,                                         \
+                uplo, trans,                                    \
+                n, k,                                           \
+                &alpha, A, lda, &beta, C, ldc));                  \
+    }
+
+#define ADD_SYRK_IMPL(ScalarType, TypeChar)             \
+    void Syrk(                                          \
+        cublasHandle_t handle,                          \
+        cublasFillMode_t uplo, cublasOperation_t trans, \
+        int n, int k,                                   \
+        ScalarType const& alpha,                        \
+        ScalarType const* A, int lda,                   \
+        ScalarType const& beta,                         \
+        ScalarType* C, int ldc)                         \
+    {                                                   \
+        H_CHECK_CUBLAS(                                 \
+            cublas ## TypeChar ## syrk(                 \
+                handle,                                 \
+                uplo, trans,                            \
+                n, k,                                   \
+                &alpha, A, lda, &beta, C, ldc));        \
+    }
+
 #define ADD_GEMM_IMPL(ScalarType, TypeChar)             \
     void Gemm(                                          \
         cublasHandle_t handle,                          \
@@ -320,6 +356,14 @@ ADD_GEMV_IMPL(cuComplex, C)
 ADD_GEMV_IMPL(cuDoubleComplex, Z)
 
 // BLAS 3
+ADD_HERK_IMPL(cuComplex, float, C)
+ADD_HERK_IMPL(cuDoubleComplex, double, Z)
+
+ADD_SYRK_IMPL(float, S)
+ADD_SYRK_IMPL(double, D)
+ADD_SYRK_IMPL(cuComplex, C)
+ADD_SYRK_IMPL(cuDoubleComplex, Z)
+
 ADD_GEMM_IMPL(__half, H)
 ADD_GEMM_IMPL(float, S)
 ADD_GEMM_IMPL(double, D)

--- a/src/hydrogen/device/cuSOLVER.cpp
+++ b/src/hydrogen/device/cuSOLVER.cpp
@@ -1,0 +1,128 @@
+#include <hydrogen/device/gpu/cuda/cuSOLVER.hpp>
+
+// Helper macro for converting enums to strings.
+#define H_ADD_CUSOLVER_ENUM_TO_STRING_CASE(enum_value) \
+    case enum_value:                        \
+        return #enum_value
+
+namespace
+{
+
+std::string GetcuSOLVERErrorString(cusolverStatus_t status)
+{
+    switch (status)
+    {
+        H_ADD_CUSOLVER_ENUM_TO_STRING_CASE(CUSOLVER_STATUS_SUCCESS);
+        H_ADD_CUSOLVER_ENUM_TO_STRING_CASE(CUSOLVER_STATUS_NOT_INITIALIZED);
+        H_ADD_CUSOLVER_ENUM_TO_STRING_CASE(CUSOLVER_STATUS_ALLOC_FAILED);
+        H_ADD_CUSOLVER_ENUM_TO_STRING_CASE(CUSOLVER_STATUS_INVALID_VALUE);
+        H_ADD_CUSOLVER_ENUM_TO_STRING_CASE(CUSOLVER_STATUS_ARCH_MISMATCH);
+        H_ADD_CUSOLVER_ENUM_TO_STRING_CASE(CUSOLVER_STATUS_EXECUTION_FAILED);
+        H_ADD_CUSOLVER_ENUM_TO_STRING_CASE(CUSOLVER_STATUS_INTERNAL_ERROR);
+        H_ADD_CUSOLVER_ENUM_TO_STRING_CASE(
+            CUSOLVER_STATUS_MATRIX_TYPE_NOT_SUPPORTED);
+    default:
+        return "Unknown cuSOLVER error.";
+    }
+}
+}// namespace <anon>
+
+namespace hydrogen
+{
+namespace cusolver
+{
+namespace // <anon2>
+{
+bool cusolver_dense_is_initialized_ = false;
+cusolverDnHandle_t default_cusolver_dense_handle_;
+}// namespace <anon2>
+
+cusolverDnHandle_t GetDenseLibraryHandle() noexcept
+{
+    return default_cusolver_dense_handle_;
+}
+
+bool IsDenseInitialized() noexcept
+{
+    return cusolver_dense_is_initialized_;
+}
+
+void InitializeDense(cusolverDnHandle_t handle)
+{
+    if (!IsDenseInitialized())
+    {
+        if (!handle)
+            H_CHECK_CUSOLVER(
+                cusolverDnCreate(&default_cusolver_dense_handle_));
+        else
+            default_cusolver_dense_handle_ = handle;
+
+        H_CHECK_CUSOLVER(
+            cusolverDnSetStream(
+                GetDenseLibraryHandle(), cuda::GetDefaultStream()));
+
+        cusolver_dense_is_initialized_ = true;
+    }
+}
+
+void FinalizeDense()
+{
+    if (default_cusolver_dense_handle_)
+        H_CHECK_CUSOLVER(cusolverDnDestroy(default_cusolver_dense_handle_));
+    default_cusolver_dense_handle_ = nullptr;
+    cusolver_dense_is_initialized_ = false;
+}
+
+void ReplaceDenseLibraryHandle(cusolverDnHandle_t handle)
+{
+    H_ASSERT_FALSE(handle == nullptr,
+                   std::logic_error,
+                   "hydrogen::cusolver::ReplaceDenseLibraryHandle(): "
+                   "Detected a null cuSOLVER dense handle.");
+
+    H_ASSERT(IsDenseInitialized(),
+             std::logic_error,
+             "hydrogen::cusolver::ReplaceDenseLibraryHandle(): "
+             "cuSOLVER Dense must be initialized "
+             "before calling this function.");
+
+    if (default_cusolver_dense_handle_)
+        H_CHECK_CUSOLVER(cusolverDnDestroy(default_cusolver_dense_handle_));
+    default_cusolver_dense_handle_ = handle;
+}
+
+SyncManager::SyncManager(cusolverDnHandle_t handle,
+                         SyncInfo<Device::GPU> const& si)
+{
+    H_CHECK_CUSOLVER(
+        cusolverDnGetStream(handle, &orig_stream_));
+    H_CHECK_CUSOLVER(
+        cusolverDnSetStream(handle, si.Stream()));
+}
+
+SyncManager::~SyncManager()
+{
+    try
+    {
+        H_CHECK_CUSOLVER(
+            cusolverDnSetStream(
+                GetDenseLibraryHandle(), orig_stream_));
+    }
+    catch (std::exception const& e)
+    {
+        H_REPORT_DTOR_EXCEPTION_AND_TERMINATE(e);
+    }
+}
+
+std::string BuildcuSOLVERErrorMessage(
+    std::string const& cmd, cusolverStatus_t error_code)
+{
+    std::ostringstream oss;
+    oss << "cuSOLVER error detected in command: \"" << cmd << "\"\n\n"
+        << "    Error Code: " << error_code << "\n"
+        << "    Error Name: " << GetcuSOLVERErrorString(error_code);
+    return oss.str();
+}
+
+}// namespace cusolver
+}// namespace hydrogen

--- a/src/hydrogen/device/cuSOLVER_API.cpp
+++ b/src/hydrogen/device/cuSOLVER_API.cpp
@@ -1,0 +1,48 @@
+#include <hydrogen/device/gpu/CUDA.hpp>
+#include <hydrogen/device/gpu/cuda/cuSOLVER.hpp>
+
+#include <cuda.h>
+#include <cuda_runtime.h>
+
+#include <cusolverDn.h>
+
+namespace hydrogen
+{
+namespace cusolver
+{
+
+#define ADD_POTRF_IMPL(ScalarType, TypeChar)                    \
+    cusolver_int GetPotrfWorkspaceSize(                         \
+        cusolverDnHandle_t handle,                              \
+        cublasFillMode_t uplo,                                  \
+        cusolver_int n,                                         \
+        DeviceArray<ScalarType> A, cusolver_int lda)            \
+    {                                                           \
+        cusolver_int workspace_size;                            \
+        H_CHECK_CUSOLVER(                                       \
+            cusolverDn ## TypeChar ## potrf_bufferSize(         \
+                handle, uplo, n, A, lda, &workspace_size));     \
+        return workspace_size;                                  \
+    }                                                           \
+    void Potrf(                                                 \
+        cusolverDnHandle_t handle,                              \
+        cublasFillMode_t uplo,                                  \
+        cusolver_int n,                                         \
+        DeviceArray<ScalarType> A, cusolver_int lda,            \
+        DeviceArray<ScalarType> workspace,                      \
+        cusolver_int workspace_size,                            \
+        DevicePtr<cusolver_int> devinfo)                        \
+    {                                                           \
+        H_CHECK_CUSOLVER(                                       \
+            cusolverDn ## TypeChar ## potrf(                    \
+                handle, uplo, n, A, lda,                        \
+                workspace, workspace_size, devinfo));           \
+    }
+
+ADD_POTRF_IMPL(float, S)
+ADD_POTRF_IMPL(double, D)
+ADD_POTRF_IMPL(cuComplex, C)
+ADD_POTRF_IMPL(cuDoubleComplex, Z)
+
+} // namespace cusolver
+} // namespace hydrogen

--- a/src/hydrogen/device/rocBLAS.cpp
+++ b/src/hydrogen/device/rocBLAS.cpp
@@ -53,6 +53,8 @@ void Initialize(rocblas_handle handle)
 {
     if (!IsInitialized())
     {
+        rocblas_initialize();
+
         if (!handle)
             H_CHECK_ROCBLAS(rocblas_create_handle(&default_rocblas_handle_));
         else

--- a/src/hydrogen/device/rocBLAS.cpp
+++ b/src/hydrogen/device/rocBLAS.cpp
@@ -1,4 +1,5 @@
 #include <hydrogen/device/gpu/rocm/rocBLAS.hpp>
+#include <hydrogen/device/gpu/rocm/rocSOLVER.hpp>
 
 // Helper macro for converting enums to strings.
 #define H_ADD_ROCBLAS_ENUM_TO_STRING_CASE(enum_value) \
@@ -65,6 +66,8 @@ void Initialize(rocblas_handle handle)
                 GetLibraryHandle(), rocblas_pointer_mode_host));
 
         rocblas_is_initialized_ = true;
+
+        rocsolver::InitializeDense();
     }
 }
 

--- a/src/hydrogen/device/rocBLAS_API.cpp
+++ b/src/hydrogen/device/rocBLAS_API.cpp
@@ -16,9 +16,9 @@ namespace rocblas
 
 #define ADD_AXPY_IMPL(ScalarType, TypeChar)                     \
     void Axpy(rocblas_handle handle,                            \
-              int n, ScalarType const& alpha,                   \
-              ScalarType const* X, int incx,                    \
-              ScalarType* Y, int incy)                          \
+              rocblas_int n, ScalarType const& alpha,                   \
+              ScalarType const* X, rocblas_int incx,                    \
+              ScalarType* Y, rocblas_int incy)                          \
     {                                                           \
         H_CHECK_ROCBLAS(                                        \
             rocblas_ ## TypeChar ## axpy(                         \
@@ -28,8 +28,8 @@ namespace rocblas
 
 #define ADD_COPY_IMPL(ScalarType, TypeChar)             \
     void Copy(rocblas_handle handle,                    \
-              int n, ScalarType const* X, int incx,     \
-              ScalarType* Y, int incy)                  \
+              rocblas_int n, ScalarType const* X, rocblas_int incx,     \
+              ScalarType* Y, rocblas_int incy)                  \
     {                                                   \
         H_CHECK_ROCBLAS(                                \
             rocblas_ ## TypeChar ## copy(                 \
@@ -39,9 +39,9 @@ namespace rocblas
 
 #define ADD_DOT_IMPL(ScalarType, TypeChar)      \
     void Dot(rocblas_handle handle,             \
-             int n,                             \
-             ScalarType const* X, int incx,     \
-             ScalarType const* Y, int incy,     \
+             rocblas_int n,                             \
+             ScalarType const* X, rocblas_int incx,     \
+             ScalarType const* Y, rocblas_int incy,     \
              ScalarType* result)                \
     {                                           \
         H_CHECK_ROCBLAS(                        \
@@ -52,7 +52,7 @@ namespace rocblas
 
 #define ADD_NRM2_IMPL(ScalarType, TypeChar)             \
     void Nrm2(rocblas_handle handle,                    \
-              int n, ScalarType const* X, int incx,     \
+              rocblas_int n, ScalarType const* X, rocblas_int incx,     \
               ScalarType* result)                       \
     {                                                   \
         H_CHECK_ROCBLAS(                                \
@@ -63,8 +63,8 @@ namespace rocblas
 
 #define ADD_SCALE_IMPL(ScalarType, TypeChar)               \
     void Scale(rocblas_handle handle,                      \
-               int n, ScalarType const& alpha,             \
-               ScalarType* X, int incx)                    \
+               rocblas_int n, ScalarType const& alpha,             \
+               ScalarType* X, rocblas_int incx)                    \
     {                                                      \
         H_CHECK_ROCBLAS(                                   \
             rocblas_ ## TypeChar ## scal(                    \
@@ -77,12 +77,12 @@ namespace rocblas
 #define ADD_GEMV_IMPL(ScalarType, TypeChar)              \
     void Gemv(                                           \
         rocblas_handle handle,                           \
-        rocblas_operation transpA, int m, int n,         \
+        rocblas_operation transpA, rocblas_int m, rocblas_int n,         \
         ScalarType const& alpha,                         \
-        ScalarType const* A, int lda,                    \
-        ScalarType const* B, int ldb,                    \
+        ScalarType const* A, rocblas_int lda,                    \
+        ScalarType const* B, rocblas_int ldb,                    \
         ScalarType const& beta,                          \
-        ScalarType* C, int ldc)                          \
+        ScalarType* C, rocblas_int ldc)                          \
     {                                                    \
         H_CHECK_ROCBLAS(rocblas_ ## TypeChar ## gemv(      \
                             handle,                      \
@@ -95,24 +95,61 @@ namespace rocblas
 //
 // BLAS 3
 //
+
+#define ADD_HERK_IMPL(ScalarType, BaseScalarType, TypeChar)     \
+    void Herk(                                                  \
+        rocblas_handle handle,                                  \
+        rocblas_fill_mode uplo, rocblas_operation trans,        \
+        rocblas_int n, rocblas_int k,                                           \
+        BaseScalarType const& alpha,                            \
+        ScalarType const* A, rocblas_int lda,                           \
+        BaseScalarType const& beta,                             \
+        ScalarType * C, rocblas_int ldc)                                \
+    {                                                           \
+        H_CHECK_ROCBLAS(                                        \
+            rocblas_ ## TypeChar ## herk(                       \
+            handle,                                             \
+            uplo, trans,                                        \
+            n, k,                                               \
+            &alpha, A, lda, &beta, C, ldc));                    \
+    }
+
+#define ADD_SYRK_IMPL(ScalarType, TypeChar)                     \
+    void Syrk(                                                  \
+        rocblas_handle handle,                                  \
+        rocblas_fill_mode uplo, rocblas_operation trans,        \
+        rocblas_int n, rocblas_int k,                                           \
+        ScalarType const& alpha,                                \
+        ScalarType const* A, rocblas_int lda,                           \
+        ScalarType const& beta,                                 \
+        ScalarType* C, rocblas_int ldc)                                 \
+    {                                                           \
+        H_CHECK_ROCBLAS(                                        \
+            rocblas_ ## TypeChar ## syrk(                       \
+                handle,                                         \
+                uplo, trans,                                    \
+                n, k,                                           \
+                &alpha, A, lda, &beta, C, ldc));                \
+    }
+
 #define ADD_GEMM_IMPL(ScalarType, TypeChar)             \
     void Gemm(                                          \
         rocblas_handle handle,                          \
         rocblas_operation transpA,                      \
         rocblas_operation transpB,                      \
-        rocblas_int m, rocblas_int n, rocblas_int k,                            \
+        rocblas_int m, rocblas_int n, rocblas_int k,    \
         ScalarType const& alpha,                        \
-        ScalarType const* A, rocblas_int lda,                   \
-        ScalarType const* B, rocblas_int ldb,                   \
+        ScalarType const* A, rocblas_int lda,           \
+        ScalarType const* B, rocblas_int ldb,           \
         ScalarType const& beta,                         \
-        ScalarType* C, rocblas_int ldc)                         \
+        ScalarType* C, rocblas_int ldc)                 \
     {                                                   \
         H_CHECK_ROCBLAS(                                \
-            rocblas_ ## TypeChar ## gemm(                 \
-                handle,                                 \
-                transpA, transpB,                       \
-                m, n, k, &alpha, A, lda, B, ldb,        \
-                &beta, C, ldc));                        \
+            rocblas_ ## TypeChar ## gemm(               \
+            handle,                                     \
+            transpA, transpB,                           \
+            m, n, k, &alpha, A, lda, B, ldb,            \
+            &beta, C, ldc));                            \
     }
 
 #define ADD_GEMM_STRIDED_BATCHED_IMPL(ScalarType, TypeChar)             \
@@ -146,12 +183,12 @@ namespace rocblas
         rocblas_handle handle,                  \
         rocblas_operation transpA,              \
         rocblas_operation transpB,              \
-        int m, int n,                           \
+        rocblas_int m, rocblas_int n,                           \
         ScalarType const& alpha,                \
-        ScalarType const* A, int lda,           \
+        ScalarType const* A, rocblas_int lda,           \
         ScalarType const& beta,                 \
-        ScalarType const* B, int ldb,           \
-        ScalarType* C, int ldc)                 \
+        ScalarType const* B, rocblas_int ldb,           \
+        ScalarType* C, rocblas_int ldc)                 \
     {                                           \
         H_CHECK_ROCBLAS(                        \
             rocblas_ ## TypeChar ## geam(       \
@@ -163,16 +200,23 @@ namespace rocblas
                 C, ldc));                       \
     }
 
-#define ADD_DGMM_IMPL(ScalarType, TypeChar)                     \
-    void Dgmm(                                                  \
-        rocblas_handle handle,                                  \
-        rocblas_side side,                                      \
-        int m, int n,                                           \
-        ScalarType const* A, int lda,                           \
-        ScalarType const* X, int incx,                          \
-        ScalarType* C, int ldc)                                 \
-    {                                                           \
-        H_CHECK_ROCBLAS(rocblas_status_not_implemented);        \
+#define ADD_DGMM_IMPL(ScalarType, TypeChar)             \
+    void Dgmm(                                          \
+        rocblas_handle handle,                          \
+        rocblas_side side,                              \
+        rocblas_int m, rocblas_int n,                   \
+        ScalarType const* A, rocblas_int lda,           \
+        ScalarType const* X, rocblas_int incx,          \
+        ScalarType* C, rocblas_int ldc)                 \
+    {                                                   \
+        H_CHECK_ROCBLAS(                                \
+            rocblas_ ## TypeChar ## dgmm(               \
+                handle,                                 \
+                side,                                   \
+                m, n,                                   \
+                A, lda,                                 \
+                X, incx,                                \
+                C, ldc));                               \
     }
 
 // BLAS 1
@@ -199,6 +243,14 @@ ADD_GEMV_IMPL(float, s)
 ADD_GEMV_IMPL(double, d)
 
 // BLAS 3
+ADD_HERK_IMPL(rocblas_float_complex, float, c)
+ADD_HERK_IMPL(rocblas_float_complex, float, z)
+
+ADD_SYRK_IMPL(float, s)
+ADD_SYRK_IMPL(double, d)
+ADD_SYRK_IMPL(rocblas_float_complex, c)
+ADD_SYRK_IMPL(rocblas_double_complex, z)
+
 ADD_GEMM_IMPL(rocblas_half, h)
 ADD_GEMM_IMPL(float, s)
 ADD_GEMM_IMPL(double, d)

--- a/src/hydrogen/device/rocBLAS_API.cpp
+++ b/src/hydrogen/device/rocBLAS_API.cpp
@@ -14,82 +14,82 @@ namespace rocblas
 // BLAS 1
 //
 
-#define ADD_AXPY_IMPL(ScalarType, TypeChar)                     \
-    void Axpy(rocblas_handle handle,                            \
-              rocblas_int n, ScalarType const& alpha,                   \
-              ScalarType const* X, rocblas_int incx,                    \
-              ScalarType* Y, rocblas_int incy)                          \
-    {                                                           \
-        H_CHECK_ROCBLAS(                                        \
-            rocblas_ ## TypeChar ## axpy(                         \
-                handle,                                         \
-                n, &alpha, X, incx, Y, incy));                  \
-    }
-
-#define ADD_COPY_IMPL(ScalarType, TypeChar)             \
-    void Copy(rocblas_handle handle,                    \
-              rocblas_int n, ScalarType const* X, rocblas_int incx,     \
-              ScalarType* Y, rocblas_int incy)                  \
+#define ADD_AXPY_IMPL(ScalarType, TypeChar)             \
+    void Axpy(rocblas_handle handle,                    \
+              rocblas_int n, ScalarType const& alpha,   \
+              ScalarType const* X, rocblas_int incx,    \
+              ScalarType* Y, rocblas_int incy)          \
     {                                                   \
         H_CHECK_ROCBLAS(                                \
-            rocblas_ ## TypeChar ## copy(                 \
+            rocblas_ ## TypeChar ## axpy(               \
                 handle,                                 \
-                n, X, incx, Y, incy));                  \
+                n, &alpha, X, incx, Y, incy));          \
     }
 
-#define ADD_DOT_IMPL(ScalarType, TypeChar)      \
-    void Dot(rocblas_handle handle,             \
+#define ADD_COPY_IMPL(ScalarType, TypeChar)                             \
+    void Copy(rocblas_handle handle,                                    \
+              rocblas_int n, ScalarType const* X, rocblas_int incx,     \
+              ScalarType* Y, rocblas_int incy)                          \
+    {                                                                   \
+        H_CHECK_ROCBLAS(                                                \
+            rocblas_ ## TypeChar ## copy(                               \
+                handle,                                                 \
+                n, X, incx, Y, incy));                                  \
+    }
+
+#define ADD_DOT_IMPL(ScalarType, TypeChar)              \
+    void Dot(rocblas_handle handle,                     \
              rocblas_int n,                             \
              ScalarType const* X, rocblas_int incx,     \
              ScalarType const* Y, rocblas_int incy,     \
-             ScalarType* result)                \
-    {                                           \
-        H_CHECK_ROCBLAS(                        \
-            rocblas_ ## TypeChar ## dot(        \
-                handle,                         \
-                n, X, incx, Y, incy, result));  \
-    }
-
-#define ADD_NRM2_IMPL(ScalarType, TypeChar)             \
-    void Nrm2(rocblas_handle handle,                    \
-              rocblas_int n, ScalarType const* X, rocblas_int incx,     \
-              ScalarType* result)                       \
+             ScalarType* result)                        \
     {                                                   \
         H_CHECK_ROCBLAS(                                \
-            rocblas_ ## TypeChar ## nrm2(               \
+            rocblas_ ## TypeChar ## dot(                \
                 handle,                                 \
-                n, X, incx, result));                   \
+                n, X, incx, Y, incy, result));          \
     }
 
-#define ADD_SCALE_IMPL(ScalarType, TypeChar)               \
-    void Scale(rocblas_handle handle,                      \
-               rocblas_int n, ScalarType const& alpha,             \
-               ScalarType* X, rocblas_int incx)                    \
-    {                                                      \
-        H_CHECK_ROCBLAS(                                   \
-            rocblas_ ## TypeChar ## scal(                    \
-                handle, n, &alpha, X, incx));              \
+#define ADD_NRM2_IMPL(ScalarType, TypeChar)                             \
+    void Nrm2(rocblas_handle handle,                                    \
+              rocblas_int n, ScalarType const* X, rocblas_int incx,     \
+              ScalarType* result)                                       \
+    {                                                                   \
+        H_CHECK_ROCBLAS(                                                \
+            rocblas_ ## TypeChar ## nrm2(                               \
+                handle,                                                 \
+                n, X, incx, result));                                   \
+    }
+
+#define ADD_SCALE_IMPL(ScalarType, TypeChar)            \
+    void Scale(rocblas_handle handle,                   \
+               rocblas_int n, ScalarType const& alpha,  \
+               ScalarType* X, rocblas_int incx)         \
+    {                                                   \
+        H_CHECK_ROCBLAS(                                \
+            rocblas_ ## TypeChar ## scal(               \
+                handle, n, &alpha, X, incx));           \
     }
 
 //
 // BLAS 2
 //
-#define ADD_GEMV_IMPL(ScalarType, TypeChar)              \
-    void Gemv(                                           \
-        rocblas_handle handle,                           \
-        rocblas_operation transpA, rocblas_int m, rocblas_int n,         \
-        ScalarType const& alpha,                         \
-        ScalarType const* A, rocblas_int lda,                    \
-        ScalarType const* B, rocblas_int ldb,                    \
-        ScalarType const& beta,                          \
-        ScalarType* C, rocblas_int ldc)                          \
-    {                                                    \
-        H_CHECK_ROCBLAS(rocblas_ ## TypeChar ## gemv(      \
-                            handle,                      \
-                            transpA,                     \
-                            m, n,                        \
-                            &alpha, A, lda, B, ldb,      \
-                            &beta, C, ldc));             \
+#define ADD_GEMV_IMPL(ScalarType, TypeChar)                             \
+    void Gemv(                                                          \
+        rocblas_handle handle,                                          \
+        rocblas_operation transpA, rocblas_int m, rocblas_int n,        \
+        ScalarType const& alpha,                                        \
+        ScalarType const* A, rocblas_int lda,                           \
+        ScalarType const* B, rocblas_int ldb,                           \
+        ScalarType const& beta,                                         \
+        ScalarType* C, rocblas_int ldc)                                 \
+    {                                                                   \
+        H_CHECK_ROCBLAS(rocblas_ ## TypeChar ## gemv(                   \
+                            handle,                                     \
+                            transpA,                                    \
+                            m, n,                                       \
+                            &alpha, A, lda, B, ldb,                     \
+                            &beta, C, ldc));                            \
     }
 
 //
@@ -99,37 +99,53 @@ namespace rocblas
 #define ADD_HERK_IMPL(ScalarType, BaseScalarType, TypeChar)     \
     void Herk(                                                  \
         rocblas_handle handle,                                  \
-        rocblas_fill_mode uplo, rocblas_operation trans,        \
-        rocblas_int n, rocblas_int k,                                           \
+        rocblas_fill uplo, rocblas_operation trans,             \
+        rocblas_int n, rocblas_int k,                           \
         BaseScalarType const& alpha,                            \
-        ScalarType const* A, rocblas_int lda,                           \
+        ScalarType const* A, rocblas_int lda,                   \
         BaseScalarType const& beta,                             \
-        ScalarType * C, rocblas_int ldc)                                \
+        ScalarType * C, rocblas_int ldc)                        \
     {                                                           \
         H_CHECK_ROCBLAS(                                        \
             rocblas_ ## TypeChar ## herk(                       \
-            handle,                                             \
-            uplo, trans,                                        \
-            n, k,                                               \
-            &alpha, A, lda, &beta, C, ldc));                    \
-    }
-
-#define ADD_SYRK_IMPL(ScalarType, TypeChar)                     \
-    void Syrk(                                                  \
-        rocblas_handle handle,                                  \
-        rocblas_fill_mode uplo, rocblas_operation trans,        \
-        rocblas_int n, rocblas_int k,                                           \
-        ScalarType const& alpha,                                \
-        ScalarType const* A, rocblas_int lda,                           \
-        ScalarType const& beta,                                 \
-        ScalarType* C, rocblas_int ldc)                                 \
-    {                                                           \
-        H_CHECK_ROCBLAS(                                        \
-            rocblas_ ## TypeChar ## syrk(                       \
                 handle,                                         \
                 uplo, trans,                                    \
                 n, k,                                           \
                 &alpha, A, lda, &beta, C, ldc));                \
+    }
+
+#define ADD_SYRK_IMPL(ScalarType, TypeChar)             \
+    void Syrk(                                          \
+        rocblas_handle handle,                          \
+        rocblas_fill uplo, rocblas_operation trans,     \
+        rocblas_int n, rocblas_int k,                   \
+        ScalarType const& alpha,                        \
+        ScalarType const* A, rocblas_int lda,           \
+        ScalarType const& beta,                         \
+        ScalarType* C, rocblas_int ldc)                 \
+    {                                                   \
+        H_CHECK_ROCBLAS(                                \
+            rocblas_ ## TypeChar ## syrk(               \
+                handle,                                 \
+                uplo, trans,                            \
+                n, k,                                   \
+                &alpha, A, lda, &beta, C, ldc));        \
+    }
+
+#define ADD_TRSM_IMPL(ScalarType, TypeChar)             \
+    void Trsm(                                          \
+        rocblas_handle handle,                          \
+        rocblas_side side, rocblas_fill uplo,           \
+        rocblas_operation trans, rocblas_diagonal diag, \
+        rocblas_int m, rocblas_int n,                   \
+        ScalarType const& alpha,                        \
+        ScalarType const* A, int lda,                   \
+        ScalarType* B, int ldb)                         \
+    {                                                   \
+        H_CHECK_ROCBLAS(                                \
+            rocblas_ ## TypeChar ## trsm(               \
+                handle, side, uplo, trans, diag,        \
+                m, n, &alpha, A, lda, B, ldb));         \
     }
 
 #define ADD_GEMM_IMPL(ScalarType, TypeChar)             \
@@ -146,10 +162,10 @@ namespace rocblas
     {                                                   \
         H_CHECK_ROCBLAS(                                \
             rocblas_ ## TypeChar ## gemm(               \
-            handle,                                     \
-            transpA, transpB,                           \
-            m, n, k, &alpha, A, lda, B, ldb,            \
-            &beta, C, ldc));                            \
+                handle,                                 \
+                transpA, transpB,                       \
+                m, n, k, &alpha, A, lda, B, ldb,        \
+                &beta, C, ldc));                        \
     }
 
 #define ADD_GEMM_STRIDED_BATCHED_IMPL(ScalarType, TypeChar)             \
@@ -183,12 +199,12 @@ namespace rocblas
         rocblas_handle handle,                  \
         rocblas_operation transpA,              \
         rocblas_operation transpB,              \
-        rocblas_int m, rocblas_int n,                           \
+        rocblas_int m, rocblas_int n,           \
         ScalarType const& alpha,                \
-        ScalarType const* A, rocblas_int lda,           \
+        ScalarType const* A, rocblas_int lda,   \
         ScalarType const& beta,                 \
-        ScalarType const* B, rocblas_int ldb,           \
-        ScalarType* C, rocblas_int ldc)                 \
+        ScalarType const* B, rocblas_int ldb,   \
+        ScalarType* C, rocblas_int ldc)         \
     {                                           \
         H_CHECK_ROCBLAS(                        \
             rocblas_ ## TypeChar ## geam(       \
@@ -200,23 +216,23 @@ namespace rocblas
                 C, ldc));                       \
     }
 
-#define ADD_DGMM_IMPL(ScalarType, TypeChar)             \
-    void Dgmm(                                          \
-        rocblas_handle handle,                          \
-        rocblas_side side,                              \
-        rocblas_int m, rocblas_int n,                   \
-        ScalarType const* A, rocblas_int lda,           \
-        ScalarType const* X, rocblas_int incx,          \
-        ScalarType* C, rocblas_int ldc)                 \
-    {                                                   \
-        H_CHECK_ROCBLAS(                                \
-            rocblas_ ## TypeChar ## dgmm(               \
-                handle,                                 \
-                side,                                   \
-                m, n,                                   \
-                A, lda,                                 \
-                X, incx,                                \
-                C, ldc));                               \
+#define ADD_DGMM_IMPL(ScalarType, TypeChar)     \
+    void Dgmm(                                  \
+        rocblas_handle handle,                  \
+        rocblas_side side,                      \
+        rocblas_int m, rocblas_int n,           \
+        ScalarType const* A, rocblas_int lda,   \
+        ScalarType const* X, rocblas_int incx,  \
+        ScalarType* C, rocblas_int ldc)         \
+    {                                           \
+        H_CHECK_ROCBLAS(                        \
+            rocblas_ ## TypeChar ## dgmm(       \
+                handle,                         \
+                side,                           \
+                m, n,                           \
+                A, lda,                         \
+                X, incx,                        \
+                C, ldc));                       \
     }
 
 // BLAS 1
@@ -244,12 +260,17 @@ ADD_GEMV_IMPL(double, d)
 
 // BLAS 3
 ADD_HERK_IMPL(rocblas_float_complex, float, c)
-ADD_HERK_IMPL(rocblas_float_complex, float, z)
+ADD_HERK_IMPL(rocblas_double_complex, double, z)
 
 ADD_SYRK_IMPL(float, s)
 ADD_SYRK_IMPL(double, d)
 ADD_SYRK_IMPL(rocblas_float_complex, c)
 ADD_SYRK_IMPL(rocblas_double_complex, z)
+
+ADD_TRSM_IMPL(float, s)
+ADD_TRSM_IMPL(double, d)
+ADD_TRSM_IMPL(rocblas_float_complex, c)
+ADD_TRSM_IMPL(rocblas_double_complex, z)
 
 ADD_GEMM_IMPL(rocblas_half, h)
 ADD_GEMM_IMPL(float, s)
@@ -282,7 +303,7 @@ ASSERT_SUPPORT(float, BLAS_Op::GEAM);
 ASSERT_SUPPORT(float, BLAS_Op::GEMM);
 ASSERT_SUPPORT(float, BLAS_Op::GEMV);
 ASSERT_SUPPORT(float, BLAS_Op::SCAL);
-ASSERT_NO_SUPPORT(float, BLAS_Op::DGMM);
+ASSERT_SUPPORT(float, BLAS_Op::DGMM);
 ASSERT_SUPPORT(float, BLAS_Op::DOT);
 ASSERT_SUPPORT(float, BLAS_Op::NRM2);
 ASSERT_SUPPORT(float, BLAS_Op::GEMMSTRIDEDBATCHED);
@@ -293,7 +314,7 @@ ASSERT_SUPPORT(double, BLAS_Op::GEAM);
 ASSERT_SUPPORT(double, BLAS_Op::GEMM);
 ASSERT_SUPPORT(double, BLAS_Op::GEMV);
 ASSERT_SUPPORT(double, BLAS_Op::SCAL);
-ASSERT_NO_SUPPORT(double, BLAS_Op::DGMM);
+ASSERT_SUPPORT(double, BLAS_Op::DGMM);
 ASSERT_SUPPORT(double, BLAS_Op::DOT);
 ASSERT_SUPPORT(double, BLAS_Op::NRM2);
 ASSERT_SUPPORT(double, BLAS_Op::GEMMSTRIDEDBATCHED);

--- a/src/hydrogen/device/rocSOLVER.cpp
+++ b/src/hydrogen/device/rocSOLVER.cpp
@@ -1,0 +1,39 @@
+#include <hydrogen/device/gpu/rocm/rocSOLVER.hpp>
+
+namespace hydrogen
+{
+namespace rocsolver
+{
+namespace // <anon>
+{
+bool rocsolver_is_initialized_ = false;
+}// namespace <anon>
+
+rocblas_handle GetDenseLibraryHandle() noexcept
+{
+    return rocblas::GetLibraryHandle();
+}
+
+bool IsDenseInitialized() noexcept
+{
+    return rocsolver_is_initialized_;
+}
+
+void InitializeDense(rocblas_handle handle)
+{
+    rocblas::Initialize(handle);
+    rocsolver_is_initialized_ = true;
+}
+
+void FinalizeDense()
+{
+    rocblas::Finalize();
+}
+
+void ReplaceDenseLibraryHandle(rocblas_handle handle)
+{
+    rocblas::ReplaceLibraryHandle(handle);
+}
+
+}// namespace rocsolver
+}// namespace hydrogen

--- a/src/hydrogen/device/rocSOLVER.cpp
+++ b/src/hydrogen/device/rocSOLVER.cpp
@@ -28,6 +28,7 @@ void InitializeDense(rocblas_handle handle)
 void FinalizeDense()
 {
     rocblas::Finalize();
+    rocsolver_is_initialized_ = false;
 }
 
 void ReplaceDenseLibraryHandle(rocblas_handle handle)

--- a/src/hydrogen/device/rocSOLVER_API.cpp
+++ b/src/hydrogen/device/rocSOLVER_API.cpp
@@ -1,0 +1,41 @@
+#include <hydrogen/device/gpu/ROCm.hpp>
+#include <hydrogen/device/gpu/rocm/rocSOLVER.hpp>
+
+#include <rocsolver.h>
+
+namespace hydrogen
+{
+namespace rocsolver
+{
+
+#define ADD_POTRF_IMPL(ScalarType, TypeChar)                    \
+    rocblas_int GetPotrfWorkspaceSize(                          \
+        rocblas_handle /*handle*/,                              \
+        rocblas_fill /*uplo*/,                                  \
+        rocblas_int /*n*/,                                      \
+        DeviceArray<ScalarType> /*A*/, rocblas_int /*lda*/)     \
+    {                                                           \
+        return rocblas_int(0);                                  \
+    }                                                           \
+    void Potrf(                                                 \
+        rocblas_handle handle,                                  \
+        rocblas_fill uplo,                                      \
+        rocblas_int n,                                          \
+        DeviceArray<ScalarType> A, rocblas_int lda,             \
+        DeviceArray<ScalarType> /*workspace*/,                  \
+        rocblas_int /*workspace_size*/,                         \
+        DevicePtr<rocblas_int> devinfo)                         \
+    {                                                           \
+        H_CHECK_ROCSOLVER(                                       \
+            rocsolver_ ## TypeChar ## potrf(                    \
+                handle, uplo, n, A, lda,                        \
+                devinfo));                                      \
+    }
+
+ADD_POTRF_IMPL(float, s)
+ADD_POTRF_IMPL(double, d)
+ADD_POTRF_IMPL(rocblas_float_complex, c)
+ADD_POTRF_IMPL(rocblas_double_complex, z)
+
+} // namespace rocsolver
+} // namespace hydrogen

--- a/src/lapack_like/CMakeLists.txt
+++ b/src/lapack_like/CMakeLists.txt
@@ -2,7 +2,7 @@
 #add_subdirectory(condense)
 #add_subdirectory(equilibrate)
 #add_subdirectory(euclidean_min)
-#add_subdirectory(factor)
+add_subdirectory(factor)
 #add_subdirectory(funcs)
 #add_subdirectory(perm)
 add_subdirectory(props)

--- a/src/lapack_like/factor/CMakeLists.txt
+++ b/src/lapack_like/factor/CMakeLists.txt
@@ -1,24 +1,24 @@
 # Add the source files for this directory
 set_full_path(THIS_DIR_SOURCES
   Cholesky.cpp
-  GQR.cpp
-  GRQ.cpp
-  ID.cpp
-  LDL.cpp
-  LQ.cpp
-  LU.cpp
-  QR.cpp
-  RQ.cpp
-  Skeleton.cpp
+#  GQR.cpp
+#  GRQ.cpp
+#  ID.cpp
+#  LDL.cpp
+#  LQ.cpp
+#  LU.cpp
+#  QR.cpp
+#  RQ.cpp
+#  Skeleton.cpp
   )
 
 # Add the subdirectories
 add_subdirectory(Cholesky)
 #add_subdirectory(LDL)
-add_subdirectory(LQ)
-add_subdirectory(LU)
-add_subdirectory(QR)
-add_subdirectory(RQ)
+#add_subdirectory(LQ)
+#add_subdirectory(LU)
+#add_subdirectory(QR)
+#add_subdirectory(RQ)
 #add_subdirectory(RegularizedLDL)
 
 # Propagate the files up the tree

--- a/src/lapack_like/factor/Cholesky.cpp
+++ b/src/lapack_like/factor/Cholesky.cpp
@@ -23,129 +23,147 @@ namespace El {
 
 // TODO: Pivoted Reverse Cholesky?
 
-template<typename F>
-void Cholesky( UpperOrLower uplo, Matrix<F>& A )
+template <typename F, Device D>
+void Cholesky(UpperOrLower uplo, Matrix<F,D>& A)
 {
-    EL_DEBUG_CSE
-    EL_DEBUG_ONLY(
-      if( A.Height() != A.Width() )
-          LogicError("A must be square");
-    )
-    if( uplo == LOWER )
-        cholesky::LowerVariant3Blocked( A );
+    EL_DEBUG_CSE;
+#ifndef EL_RELEASE
+    if (A.Height() != A.Width())
+        LogicError("A must be square");
+#endif // EL_RELEASE
+    if (uplo == LOWER)
+        cholesky::LowerVariant3Blocked(A);
     else
-        cholesky::UpperVariant3Blocked( A );
+        cholesky::UpperVariant3Blocked(A);
+}
+
+template <typename F>
+void Cholesky(UpperOrLower uplo, AbstractMatrix<F>& A)
+{
+    switch (A.GetDevice())
+    {
+    case Device::CPU:
+        Cholesky(uplo, static_cast<Matrix<F,Device::CPU>&>(A));
+        break;
+#ifdef HYDROGEN_HAVE_GPU
+    case Device::GPU:
+        Cholesky(uplo, static_cast<Matrix<F,Device::GPU>&>(A));
+        break;
+#endif // HYDROGEN_HAVE_GPU
+    default:
+        RuntimeError("Bad device.");
+    }
 }
 
 #ifdef HYDROGEN_ENABLE_PIVOTED_CHOLESKY
-template<typename F>
-void Cholesky( UpperOrLower uplo, Matrix<F>& A, Permutation& p )
+template <typename F>
+void Cholesky(UpperOrLower uplo, Matrix<F>& A, Permutation& p)
 {
-    EL_DEBUG_CSE
+    EL_DEBUG_CSE;
     EL_DEBUG_ONLY(
-      if( A.Height() != A.Width() )
+      if (A.Height() != A.Width())
           LogicError("A must be square");
-    )
-    if( uplo == LOWER )
-        cholesky::PivotedLowerVariant3Blocked( A, p );
+   )
+    if (uplo == LOWER)
+        cholesky::PivotedLowerVariant3Blocked(A, p);
     else
-        cholesky::PivotedUpperVariant3Blocked( A, p );
+        cholesky::PivotedUpperVariant3Blocked(A, p);
 }
 #endif // HYDROGEN_ENABLE_PIVOTED_CHOLESKY
 
 #ifdef HYDROGEN_ENABLE_REVERSE_CHOLESKY
-template<typename F>
-void ReverseCholesky( UpperOrLower uplo, Matrix<F>& A )
+template <typename F>
+void ReverseCholesky(UpperOrLower uplo, Matrix<F>& A)
 {
-    EL_DEBUG_CSE
-    EL_DEBUG_ONLY(
-      if( A.Height() != A.Width() )
+    EL_DEBUG_CSE;
+#ifndef EL_RELEASE
+      if (A.Height() != A.Width())
           LogicError("A must be square");
-    )
-    if( uplo == LOWER )
-        cholesky::ReverseLowerVariant3Blocked( A );
+#endif // EL_RELEASE
+    if (uplo == LOWER)
+        cholesky::ReverseLowerVariant3Blocked(A);
     else
-        cholesky::ReverseUpperVariant3Blocked( A );
+        cholesky::ReverseUpperVariant3Blocked(A);
 }
 #endif // HYDROGEN_ENABLE_REVERSE_CHOLESKY
 
 namespace cholesky {
 
-template<typename F,typename=EnableIf<IsBlasScalar<F>>>
-void ScaLAPACKHelper( UpperOrLower uplo, AbstractDistMatrix<F>& A )
+template <typename F,typename=EnableIf<IsBlasScalar<F>>>
+void ScaLAPACKHelper(UpperOrLower uplo, AbstractDistMatrix<F>& A)
 {
     AssertScaLAPACKSupport();
 #ifdef EL_HAVE_SCALAPACK
     // TODO: Add support for optionally timing the proxy redistribution
-    DistMatrixReadWriteProxy<F,F,MC,MR,BLOCK> ABlockProx( A );
+    DistMatrixReadWriteProxy<F,F,MC,MR,BLOCK> ABlockProx(A);
     auto& ABlock = ABlockProx.Get();
 
     const Int n = ABlock.Height();
-    const char uploChar = UpperOrLowerToChar( uplo );
+    const char uploChar = UpperOrLowerToChar(uplo);
 
-    auto descA = FillDesc( ABlock );
-    scalapack::Cholesky( uploChar, n, ABlock.Buffer(), descA.data() );
+    auto descA = FillDesc(ABlock);
+    scalapack::Cholesky(uploChar, n, ABlock.Buffer(), descA.data());
 #endif
 }
 
-template<typename F,typename=DisableIf<IsBlasScalar<F>>,typename=void>
-void ScaLAPACKHelper( UpperOrLower uplo, AbstractDistMatrix<F>& A )
+template <typename F,typename=DisableIf<IsBlasScalar<F>>,typename=void>
+void ScaLAPACKHelper(UpperOrLower uplo, AbstractDistMatrix<F>& A)
 {
     RuntimeError("There is no ScaLAPACK support for this datatype");
 }
 
 } // anonymous namespace
 
-template<typename F>
-void Cholesky( UpperOrLower uplo, AbstractDistMatrix<F>& A, bool scalapack )
+template <typename F>
+void Cholesky(UpperOrLower uplo, AbstractDistMatrix<F>& A, bool scalapack)
 {
-    EL_DEBUG_CSE
-    if( scalapack )
+    EL_DEBUG_CSE;
+    if (scalapack)
     {
-        cholesky::ScaLAPACKHelper( uplo, A );
+        cholesky::ScaLAPACKHelper(uplo, A);
     }
     else
     {
-        if( uplo == LOWER )
-            cholesky::LowerVariant3Blocked( A );
+        if (uplo == LOWER)
+            cholesky::LowerVariant3Blocked(A);
         else
-            cholesky::UpperVariant3Blocked( A );
+            cholesky::UpperVariant3Blocked(A);
     }
 }
 
 #ifdef HYDROGEN_ENABLE_PIVOTED_CHOLESKY
-template<typename F>
+template <typename F>
 void Cholesky
-( UpperOrLower uplo, AbstractDistMatrix<F>& A, DistPermutation& p )
+(UpperOrLower uplo, AbstractDistMatrix<F>& A, DistPermutation& p)
 {
-    EL_DEBUG_CSE
-    if( uplo == LOWER )
-        cholesky::PivotedLowerVariant3Blocked( A, p );
+    EL_DEBUG_CSE;
+    if (uplo == LOWER)
+        cholesky::PivotedLowerVariant3Blocked(A, p);
     else
-        cholesky::PivotedUpperVariant3Blocked( A, p );
+        cholesky::PivotedUpperVariant3Blocked(A, p);
 }
 #endif // HYDROGEN_ENABLE_PIVOTED_CHOLESKY
 
-template<typename F>
+template <typename F>
 void Cholesky
-( UpperOrLower uplo, DistMatrix<F,STAR,STAR>& A )
-{ Cholesky( uplo, A.Matrix() ); }
+(UpperOrLower uplo, DistMatrix<F,STAR,STAR>& A)
+{ Cholesky(uplo, A.Matrix()); }
 
 #ifdef HYDROGEN_ENABLE_REVERSE_CHOLESKY
-template<typename F>
-void ReverseCholesky( UpperOrLower uplo, AbstractDistMatrix<F>& A )
+template <typename F>
+void ReverseCholesky(UpperOrLower uplo, AbstractDistMatrix<F>& A)
 {
-    EL_DEBUG_CSE
-    if( uplo == LOWER )
-        cholesky::ReverseLowerVariant3Blocked( A );
+    EL_DEBUG_CSE;
+    if (uplo == LOWER)
+        cholesky::ReverseLowerVariant3Blocked(A);
     else
-        cholesky::ReverseUpperVariant3Blocked( A );
+        cholesky::ReverseUpperVariant3Blocked(A);
 }
 
-template<typename F>
+template <typename F>
 void ReverseCholesky
-( UpperOrLower uplo, DistMatrix<F,STAR,STAR>& A )
-{ ReverseCholesky( uplo, A.Matrix() ); }
+(UpperOrLower uplo, DistMatrix<F,STAR,STAR>& A)
+{ ReverseCholesky(uplo, A.Matrix()); }
 #endif // HYDROGEN_ENABLE_REVERSE_CHOLESKY
 
 #ifdef HYDROGEN_ENABLE_CHOLESKY_MOD
@@ -153,119 +171,119 @@ void ReverseCholesky
 //         L' L'^H := L L^H + alpha V V^H
 // or
 //         U'^H U' := U^H U + alpha V V^H
-template<typename F>
-void CholeskyMod( UpperOrLower uplo, Matrix<F>& T, Base<F> alpha, Matrix<F>& V )
+template <typename F>
+void CholeskyMod(UpperOrLower uplo, Matrix<F>& T, Base<F> alpha, Matrix<F>& V)
 {
-    EL_DEBUG_CSE
-    if( alpha == Base<F>(0) )
+    EL_DEBUG_CSE;
+    if (alpha == Base<F>(0))
         return;
-    if( uplo == LOWER )
-        cholesky::LowerMod( T, alpha, V );
+    if (uplo == LOWER)
+        cholesky::LowerMod(T, alpha, V);
     else
-        cholesky::UpperMod( T, alpha, V );
+        cholesky::UpperMod(T, alpha, V);
 }
 
-template<typename F>
+template <typename F>
 void CholeskyMod
-( UpperOrLower uplo,
+(UpperOrLower uplo,
   AbstractDistMatrix<F>& T,
   Base<F> alpha,
-  AbstractDistMatrix<F>& V )
+  AbstractDistMatrix<F>& V)
 {
-    EL_DEBUG_CSE
-    if( alpha == Base<F>(0) )
+    EL_DEBUG_CSE;
+    if (alpha == Base<F>(0))
         return;
-    if( uplo == LOWER )
-        cholesky::LowerMod( T, alpha, V );
+    if (uplo == LOWER)
+        cholesky::LowerMod(T, alpha, V);
     else
-        cholesky::UpperMod( T, alpha, V );
+        cholesky::UpperMod(T, alpha, V);
 }
 
-template<typename F>
-void HPSDCholesky( UpperOrLower uplo, Matrix<F>& A )
+template <typename F>
+void HPSDCholesky(UpperOrLower uplo, Matrix<F>& A)
 {
-    EL_DEBUG_CSE
-    HPSDSquareRoot( uplo, A );
-    MakeHermitian( uplo, A );
+    EL_DEBUG_CSE;
+    HPSDSquareRoot(uplo, A);
+    MakeHermitian(uplo, A);
 
-    if( uplo == LOWER )
-        lq::ExplicitTriang( A );
+    if (uplo == LOWER)
+        lq::ExplicitTriang(A);
     else
-        qr::ExplicitTriang( A );
+        qr::ExplicitTriang(A);
 }
 
-template<typename F>
-void HPSDCholesky( UpperOrLower uplo, AbstractDistMatrix<F>& APre )
+template <typename F>
+void HPSDCholesky(UpperOrLower uplo, AbstractDistMatrix<F>& APre)
 {
-    EL_DEBUG_CSE
+    EL_DEBUG_CSE;
 
     // NOTE: This should be removed once HPSD, LQ, and QR have been generalized
-    DistMatrixReadWriteProxy<F,F,MC,MR> AProx( APre );
+    DistMatrixReadWriteProxy<F,F,MC,MR> AProx(APre);
     auto& A = AProx.Get();
 
-    HPSDSquareRoot( uplo, A );
-    MakeHermitian( uplo, A );
+    HPSDSquareRoot(uplo, A);
+    MakeHermitian(uplo, A);
 
-    if( uplo == LOWER )
-        lq::ExplicitTriang( A );
+    if (uplo == LOWER)
+        lq::ExplicitTriang(A);
     else
-        qr::ExplicitTriang( A );
+        qr::ExplicitTriang(A);
 }
 #endif // HYDROGEN_ENABLE_CHOLESKY_MOD
 
 #define PROTO(F)                                                        \
-    template void Cholesky( UpperOrLower uplo, Matrix<F>& A );          \
+    template void Cholesky(UpperOrLower uplo, AbstractMatrix<F>& A);    \
     template void Cholesky(                                             \
-        UpperOrLower uplo, AbstractDistMatrix<F>& A, bool scalapack );  \
+        UpperOrLower uplo, AbstractDistMatrix<F>& A, bool scalapack);   \
     template void Cholesky(                                             \
-        UpperOrLower uplo, DistMatrix<F,STAR,STAR>& A );
+        UpperOrLower uplo, DistMatrix<F,STAR,STAR>& A);
 
 #ifdef HYDROGEN_ENABLE_ALL_CHOLESKY
 #define PROTO_BASE(F) \
-  template void Cholesky( UpperOrLower uplo, Matrix<F>& A ); \
-  template void Cholesky \
-  ( UpperOrLower uplo, AbstractDistMatrix<F>& A, bool scalapack ); \
-  template void Cholesky( UpperOrLower uplo, DistMatrix<F,STAR,STAR>& A ); \
-  template void ReverseCholesky( UpperOrLower uplo, Matrix<F>& A ); \
+  template void Cholesky(UpperOrLower uplo, Matrix<F>& A); \
+  template void Cholesky(                                        \
+      UpperOrLower uplo, AbstractDistMatrix<F>& A, bool scalapack);     \
+  template void Cholesky(UpperOrLower uplo, DistMatrix<F,STAR,STAR>& A); \
+  template void ReverseCholesky(UpperOrLower uplo, Matrix<F>& A); \
   template void ReverseCholesky \
-  ( UpperOrLower uplo, AbstractDistMatrix<F>& A ); \
+  (UpperOrLower uplo, AbstractDistMatrix<F>& A); \
   template void ReverseCholesky \
-  ( UpperOrLower uplo, DistMatrix<F,STAR,STAR>& A ); \
-  template void Cholesky( UpperOrLower uplo, Matrix<F>& A, Permutation& p ); \
+  (UpperOrLower uplo, DistMatrix<F,STAR,STAR>& A); \
+  template void Cholesky(UpperOrLower uplo, Matrix<F>& A, Permutation& p); \
   template void Cholesky \
-  ( UpperOrLower uplo, \
+  (UpperOrLower uplo, \
     AbstractDistMatrix<F>& A, \
-    DistPermutation& p ); \
+    DistPermutation& p); \
   template void CholeskyMod \
-  ( UpperOrLower uplo, Matrix<F>& T, Base<F> alpha, Matrix<F>& V ); \
+  (UpperOrLower uplo, Matrix<F>& T, Base<F> alpha, Matrix<F>& V); \
   template void CholeskyMod \
-  ( UpperOrLower uplo, \
+  (UpperOrLower uplo, \
     AbstractDistMatrix<F>& T, \
     Base<F> alpha, \
-    AbstractDistMatrix<F>& V ); \
+    AbstractDistMatrix<F>& V); \
   template void cholesky::SolveAfter \
-  ( UpperOrLower uplo, Orientation orientation, \
+  (UpperOrLower uplo, Orientation orientation, \
     const Matrix<F>& A, \
-          Matrix<F>& B ); \
+          Matrix<F>& B); \
   template void cholesky::SolveAfter \
-  ( UpperOrLower uplo, Orientation orientation, \
+  (UpperOrLower uplo, Orientation orientation, \
     const AbstractDistMatrix<F>& A, \
-          AbstractDistMatrix<F>& B ); \
+          AbstractDistMatrix<F>& B); \
   template void cholesky::SolveAfter \
-  ( UpperOrLower uplo, Orientation orientation, \
+  (UpperOrLower uplo, Orientation orientation, \
     const Matrix<F>& A, \
     const Permutation& p, \
-          Matrix<F>& B ); \
+          Matrix<F>& B); \
   template void cholesky::SolveAfter \
-  ( UpperOrLower uplo, Orientation orientation, \
+  (UpperOrLower uplo, Orientation orientation, \
     const AbstractDistMatrix<F>& A, \
     const DistPermutation& p, \
-          AbstractDistMatrix<F>& B );
+          AbstractDistMatrix<F>& B);
 
 #define PROTO(F) \
   PROTO_BASE(F) \
-  template void HPSDCholesky( UpperOrLower uplo, Matrix<F>& A ); \
-  template void HPSDCholesky( UpperOrLower uplo, AbstractDistMatrix<F>& A );
+  template void HPSDCholesky(UpperOrLower uplo, Matrix<F>& A); \
+  template void HPSDCholesky(UpperOrLower uplo, AbstractDistMatrix<F>& A);
 
 #define PROTO_DOUBLEDOUBLE PROTO_BASE(DoubleDouble)
 #define PROTO_QUADDOUBLE PROTO_BASE(QuadDouble)

--- a/src/lapack_like/factor/Cholesky.cpp
+++ b/src/lapack_like/factor/Cholesky.cpp
@@ -2,8 +2,8 @@
    Copyright (c) 2009-2016, Jack Poulson
    All rights reserved.
 
-   This file is part of Elemental and is under the BSD 2-Clause License, 
-   which can be found in the LICENSE file in the root directory, or at 
+   This file is part of Elemental and is under the BSD 2-Clause License,
+   which can be found in the LICENSE file in the root directory, or at
    http://opensource.org/licenses/BSD-2-Clause
 */
 #include <El.hpp>
@@ -37,6 +37,7 @@ void Cholesky( UpperOrLower uplo, Matrix<F>& A )
         cholesky::UpperVariant3Blocked( A );
 }
 
+#ifdef HYDROGEN_ENABLE_PIVOTED_CHOLESKY
 template<typename F>
 void Cholesky( UpperOrLower uplo, Matrix<F>& A, Permutation& p )
 {
@@ -50,7 +51,9 @@ void Cholesky( UpperOrLower uplo, Matrix<F>& A, Permutation& p )
     else
         cholesky::PivotedUpperVariant3Blocked( A, p );
 }
+#endif // HYDROGEN_ENABLE_PIVOTED_CHOLESKY
 
+#ifdef HYDROGEN_ENABLE_REVERSE_CHOLESKY
 template<typename F>
 void ReverseCholesky( UpperOrLower uplo, Matrix<F>& A )
 {
@@ -64,6 +67,7 @@ void ReverseCholesky( UpperOrLower uplo, Matrix<F>& A )
     else
         cholesky::ReverseUpperVariant3Blocked( A );
 }
+#endif // HYDROGEN_ENABLE_REVERSE_CHOLESKY
 
 namespace cholesky {
 
@@ -92,7 +96,7 @@ void ScaLAPACKHelper( UpperOrLower uplo, AbstractDistMatrix<F>& A )
 
 } // anonymous namespace
 
-template<typename F> 
+template<typename F>
 void Cholesky( UpperOrLower uplo, AbstractDistMatrix<F>& A, bool scalapack )
 {
     EL_DEBUG_CSE
@@ -109,7 +113,8 @@ void Cholesky( UpperOrLower uplo, AbstractDistMatrix<F>& A, bool scalapack )
     }
 }
 
-template<typename F> 
+#ifdef HYDROGEN_ENABLE_PIVOTED_CHOLESKY
+template<typename F>
 void Cholesky
 ( UpperOrLower uplo, AbstractDistMatrix<F>& A, DistPermutation& p )
 {
@@ -119,13 +124,15 @@ void Cholesky
     else
         cholesky::PivotedUpperVariant3Blocked( A, p );
 }
+#endif // HYDROGEN_ENABLE_PIVOTED_CHOLESKY
 
 template<typename F>
 void Cholesky
 ( UpperOrLower uplo, DistMatrix<F,STAR,STAR>& A )
 { Cholesky( uplo, A.Matrix() ); }
 
-template<typename F> 
+#ifdef HYDROGEN_ENABLE_REVERSE_CHOLESKY
+template<typename F>
 void ReverseCholesky( UpperOrLower uplo, AbstractDistMatrix<F>& A )
 {
     EL_DEBUG_CSE
@@ -139,8 +146,10 @@ template<typename F>
 void ReverseCholesky
 ( UpperOrLower uplo, DistMatrix<F,STAR,STAR>& A )
 { ReverseCholesky( uplo, A.Matrix() ); }
+#endif // HYDROGEN_ENABLE_REVERSE_CHOLESKY
 
-// Either 
+#ifdef HYDROGEN_ENABLE_CHOLESKY_MOD
+// Either
 //         L' L'^H := L L^H + alpha V V^H
 // or
 //         U'^H U' := U^H U + alpha V V^H
@@ -159,7 +168,7 @@ void CholeskyMod( UpperOrLower uplo, Matrix<F>& T, Base<F> alpha, Matrix<F>& V )
 template<typename F>
 void CholeskyMod
 ( UpperOrLower uplo,
-  AbstractDistMatrix<F>& T, 
+  AbstractDistMatrix<F>& T,
   Base<F> alpha,
   AbstractDistMatrix<F>& V )
 {
@@ -202,7 +211,16 @@ void HPSDCholesky( UpperOrLower uplo, AbstractDistMatrix<F>& APre )
     else
         qr::ExplicitTriang( A );
 }
+#endif // HYDROGEN_ENABLE_CHOLESKY_MOD
 
+#define PROTO(F)                                                        \
+    template void Cholesky( UpperOrLower uplo, Matrix<F>& A );          \
+    template void Cholesky(                                             \
+        UpperOrLower uplo, AbstractDistMatrix<F>& A, bool scalapack );  \
+    template void Cholesky(                                             \
+        UpperOrLower uplo, DistMatrix<F,STAR,STAR>& A );
+
+#ifdef HYDROGEN_ENABLE_ALL_CHOLESKY
 #define PROTO_BASE(F) \
   template void Cholesky( UpperOrLower uplo, Matrix<F>& A ); \
   template void Cholesky \
@@ -242,7 +260,7 @@ void HPSDCholesky( UpperOrLower uplo, AbstractDistMatrix<F>& APre )
   ( UpperOrLower uplo, Orientation orientation, \
     const AbstractDistMatrix<F>& A, \
     const DistPermutation& p, \
-          AbstractDistMatrix<F>& B ); 
+          AbstractDistMatrix<F>& B );
 
 #define PROTO(F) \
   PROTO_BASE(F) \
@@ -258,6 +276,7 @@ void HPSDCholesky( UpperOrLower uplo, AbstractDistMatrix<F>& APre )
 #define PROTO_BIGFLOAT PROTO_BASE(BigFloat)
 #define PROTO_COMPLEX_BIGFLOAT PROTO_BASE(Complex<BigFloat>)
 // #define PROTO_COMPLEX_HALF PROTO_BASE(Complex<cpu_half_type>)
+#endif // HYDROGEN_ENABLE_ALL_CHOLESKY
 
 #define EL_NO_INT_PROTO
 #define EL_ENABLE_DOUBLEDOUBLE

--- a/src/lapack_like/factor/Cholesky/LowerMod.hpp
+++ b/src/lapack_like/factor/Cholesky/LowerMod.hpp
@@ -52,9 +52,9 @@ void LowerUpdate( Matrix<F>& L, Matrix<F>& V )
         lambda11 = -lambda11;
         z21 = l21;
         Gemv( NORMAL, F(1), V2, v1, F(1), z21 );
-        l21 *= -1;
+        Scale(-1, l21);
         Axpy( tau, z21, l21 );
-        V2 *= -1;
+        Scale(-1, V2);
         Ger( tau, z21, v1, V2 );
     }
 }
@@ -112,9 +112,9 @@ void LowerUpdate
         LocalGemv( NORMAL, F(1), V2, v1_STAR_MR, F(0), b21_MC_STAR );
         El::AllReduce( b21_MC_STAR, V2.RowComm() );
         z21_MC_STAR += b21_MC_STAR;
-        l21 *= -1;
+        Scale(-1, l21);
         Axpy( tau, z21_MC_STAR, l21 );
-        V2 *= -1;
+        Scale(-1, V2);
         LocalGer( tau, z21_MC_STAR, v1_STAR_MR, V2 );
     }
 }
@@ -159,8 +159,8 @@ void LowerDowndate( Matrix<F>& L, Matrix<F>& V )
         lambda11 = -lambda11;
         z21 = l21;
         Gemv( NORMAL, F(-1), V2, v1, F(1), z21 );
-        l21 *= -1;
-        V2 *= -1;
+        Scale(-1, l21);
+        Scale(-1, V2);
         Axpy( F(1)/tau, z21, l21 );
         Ger( F(1)/tau, z21, v1, V2 );
     }
@@ -220,8 +220,8 @@ void LowerDowndate( AbstractDistMatrix<F>& LPre, AbstractDistMatrix<F>& VPre )
         LocalGemv( NORMAL, F(-1), V2, v1_STAR_MR, F(0), b21_MC_STAR );
         El::AllReduce( b21_MC_STAR, V2.RowComm() );
         z21_MC_STAR += b21_MC_STAR;
-        l21 *= -1;
-        V2 *= -1;
+        Scale(-1, l21);
+        Scale(-1, V2);
         Axpy( F(1)/tau, z21_MC_STAR, l21 );
         LocalGer( F(1)/tau, z21_MC_STAR, v1_STAR_MR, V2 );
     }
@@ -238,12 +238,12 @@ void LowerMod( Matrix<F>& L, Base<F> alpha, Matrix<F>& V )
         return;
     else if( alpha > Real(0) )
     {
-        V *= Sqrt(alpha);
+        Scale(Sqrt(alpha), V);
         mod::LowerUpdate( L, V );
     }
     else
     {
-        V *= Sqrt(-alpha);
+        Scale(Sqrt(-alpha), V);
         mod::LowerDowndate( L, V );
     }
 }

--- a/src/lapack_like/factor/Cholesky/LowerVariant3.hpp
+++ b/src/lapack_like/factor/Cholesky/LowerVariant3.hpp
@@ -16,12 +16,12 @@ namespace cholesky {
 template <typename F>
 void LowerVariant3Unblocked(Matrix<F, Device::GPU>& A)
 {
-    RuntimeError("Function not yet implemented.");
+    LocalGPUCholesky(FillMode::LOWER_TRIANGLE, A);
 }
 #endif // HYDROGEN_HAVE_GPU
 
-template <typename F, Device D>
-void LowerVariant3Unblocked(Matrix<F,D>& A)
+template <typename F>
+void LowerVariant3Unblocked(Matrix<F,Device::CPU>& A)
 {
     EL_DEBUG_CSE;
 #ifndef EL_RELEASE

--- a/src/lapack_like/factor/Cholesky/LowerVariant3.hpp
+++ b/src/lapack_like/factor/Cholesky/LowerVariant3.hpp
@@ -12,72 +12,79 @@
 namespace El {
 namespace cholesky {
 
-template<typename F>
-void LowerVariant3Unblocked( Matrix<F>& A )
+#ifdef HYDROGEN_HAVE_GPU
+template <typename F>
+void LowerVariant3Unblocked(Matrix<F, Device::GPU>& A)
 {
-    EL_DEBUG_CSE
-    EL_DEBUG_ONLY(
-      if( A.Height() != A.Width() )
-          LogicError("Can only compute Cholesky factor of square matrices");
-    )
-    typedef Base<F> Real;
-    const Int n = A.Height();
-    const Int ALDim = A.LDim();
-    for( Int j=0; j<n; ++j )
+    RuntimeError("Function not yet implemented.");
+}
+#endif // HYDROGEN_HAVE_GPU
+
+template <typename F, Device D>
+void LowerVariant3Unblocked(Matrix<F,D>& A)
+{
+    EL_DEBUG_CSE;
+#ifndef EL_RELEASE
+    if(A.Height() != A.Width())
+        LogicError("Can only compute Cholesky factor of square matrices");
+#endif // EL_RELEASE
+    using Real = Base<F>;
+    Int const n = A.Height();
+    Int const ALDim = A.LDim();
+    for (Int j=0; j<n; ++j)
     {
         Real alpha11 = RealPart(A(j,j));
-        if( alpha11 <= Real(0) )
+        if (alpha11 <= Real(0))
             throw NonHPDMatrixException("A was not numerically HPD");
-        alpha11 = Sqrt( alpha11 );
+        alpha11 = Sqrt(alpha11);
         A(j,j) = alpha11;
 
         const Int a21Height = n-(j+1);
-        F* a21 = A.Buffer(j+1,j  );
+        F* a21 = A.Buffer(j+1,j );
         F* A22 = A.Buffer(j+1,j+1);
 
-        blas::Scal( a21Height, Real(1)/alpha11, a21, 1 );
-        blas::Her( 'L', a21Height, -Real(1), a21, 1, A22, ALDim );
+        blas::Scal(a21Height, Real(1)/alpha11, a21, 1);
+        blas::Her('L', a21Height, -Real(1), a21, 1, A22, ALDim);
     }
 }
 
-template<typename F>
-void LowerVariant3Blocked( Matrix<F>& A )
+template <typename F, Device D>
+void LowerVariant3Blocked(Matrix<F,D>& A)
 {
-    EL_DEBUG_CSE
-    EL_DEBUG_ONLY(
-      if( A.Height() != A.Width() )
-          LogicError("Can only compute Cholesky factor of square matrices");
-    )
-    const Int n = A.Height();
-    const Int bsize = Blocksize();
-    for( Int k=0; k<n; k+=bsize )
+    EL_DEBUG_CSE;
+#ifndef EL_RELEASE
+    if(A.Height() != A.Width())
+        LogicError("Can only compute Cholesky factor of square matrices");
+#endif // EL_RELEASE
+    Int const n = A.Height();
+    Int const bsize = Blocksize();
+    for (Int k=0; k<n; k+=bsize)
     {
-        const Int nb = Min(bsize,n-k);
+        Int const nb = Min(bsize,n-k);
+        Range<Int> const ind1(k,    k+nb),
+                         ind2(k+nb, n   );
 
-        const Range<Int> ind1( k,    k+nb ),
-                         ind2( k+nb, n    );
+        auto A11 = A(ind1, ind1);
+        auto A21 = A(ind2, ind1);
+        auto A22 = A(ind2, ind2);
 
-        auto A11 = A( ind1, ind1 );
-        auto A21 = A( ind2, ind1 );
-        auto A22 = A( ind2, ind2 );
-
-        cholesky::LowerVariant3Unblocked( A11 );
-        Trsm( RIGHT, LOWER, ADJOINT, NON_UNIT, F(1), A11, A21 );
-        Herk( LOWER, NORMAL, Base<F>(-1), A21, Base<F>(1), A22 );
+        cholesky::LowerVariant3Unblocked(A11);
+        Trsm(RIGHT, LOWER, ADJOINT, NON_UNIT, F(1), A11, A21);
+        Herk(LOWER, NORMAL, Base<F>(-1), A21, Base<F>(1), A22);
     }
 }
 
-template<typename F>
-void LowerVariant3Blocked( AbstractDistMatrix<F>& APre )
+template <typename F>
+void LowerVariant3Blocked(AbstractDistMatrix<F>& APre)
 {
-    EL_DEBUG_CSE
+    EL_DEBUG_CSE;
     EL_DEBUG_ONLY(
-      if( APre.Height() != APre.Width() )
+      if(APre.Height() != APre.Width())
           LogicError("Can only compute Cholesky factor of square matrices");
-    )
+   )
     const Grid& grid = APre.Grid();
 
-    DistMatrixReadWriteProxy<F,F,MC,MR> AProx( APre );
+    DistMatrixReadWriteProxy<F,F,MC,MR> AProx(APre);
     auto& A = AProx.Get();
 
     DistMatrix<F,STAR,STAR> A11_STAR_STAR(grid);
@@ -88,40 +95,40 @@ void LowerVariant3Blocked( AbstractDistMatrix<F>& APre )
 
     const Int n = A.Height();
     const Int bsize = Blocksize();
-    for( Int k=0; k<n; k+=bsize )
+    for(Int k=0; k<n; k+=bsize)
     {
         const Int nb = Min(bsize,n-k);
 
-        const Range<Int> ind1( k,    k+nb ),
-                         ind2( k+nb, n    );
+        const Range<Int> ind1(k,    k+nb),
+                         ind2(k+nb, n   );
 
-        auto A11 = A( ind1, ind1 );
-        auto A21 = A( ind2, ind1 );
-        auto A22 = A( ind2, ind2 );
+        auto A11 = A(ind1, ind1);
+        auto A21 = A(ind2, ind1);
+        auto A22 = A(ind2, ind2);
 
         A11_STAR_STAR = A11;
-        Cholesky( LOWER, A11_STAR_STAR );
+        Cholesky(LOWER, A11_STAR_STAR);
         A11 = A11_STAR_STAR;
 
-        A21_VC_STAR.AlignWith( A22 );
+        A21_VC_STAR.AlignWith(A22);
         A21_VC_STAR = A21;
         LocalTrsm
-        ( RIGHT, LOWER, ADJOINT, NON_UNIT, F(1), A11_STAR_STAR, A21_VC_STAR );
+        (RIGHT, LOWER, ADJOINT, NON_UNIT, F(1), A11_STAR_STAR, A21_VC_STAR);
 
-        A21_VR_STAR.AlignWith( A22 );
+        A21_VR_STAR.AlignWith(A22);
         A21_VR_STAR = A21_VC_STAR;
-        A21Trans_STAR_MC.AlignWith( A22 );
-        A21Adj_STAR_MR.AlignWith( A22 );
-        Transpose( A21_VC_STAR, A21Trans_STAR_MC );
-        Adjoint( A21_VR_STAR, A21Adj_STAR_MR );
+        A21Trans_STAR_MC.AlignWith(A22);
+        A21Adj_STAR_MR.AlignWith(A22);
+        Transpose(A21_VC_STAR, A21Trans_STAR_MC);
+        Adjoint(A21_VR_STAR, A21Adj_STAR_MR);
 
         // (A21^T[* ,MC])^T A21^H[* ,MR] = A21[MC,* ] A21^H[* ,MR]
         //                               = (A21 A21^H)[MC,MR]
-        LocalTrrk
-        ( LOWER, TRANSPOSE,
-          F(-1), A21Trans_STAR_MC, A21Adj_STAR_MR, F(1), A22 );
+        LocalTrrk(
+            LOWER, TRANSPOSE,
+            F(-1), A21Trans_STAR_MC, A21Adj_STAR_MR, F(1), A22);
 
-        Transpose( A21Trans_STAR_MC, A21 );
+        Transpose(A21Trans_STAR_MC, A21);
     }
 }
 

--- a/src/lapack_like/factor/Cholesky/PivotedLowerVariant3.hpp
+++ b/src/lapack_like/factor/Cholesky/PivotedLowerVariant3.hpp
@@ -2,8 +2,8 @@
    Copyright (c) 2009-2016, Jack Poulson
    All rights reserved.
 
-   This file is part of Elemental and is under the BSD 2-Clause License, 
-   which can be found in the LICENSE file in the root directory, or at 
+   This file is part of Elemental and is under the BSD 2-Clause License,
+   which can be found in the LICENSE file in the root directory, or at
    http://opensource.org/licenses/BSD-2-Clause
 */
 #ifndef EL_CHOLESKY_PIVOTED_LOWER_VARIANT3_HPP
@@ -64,7 +64,7 @@ LDLPivot PanelFull
 
 template<typename F>
 LDLPivot PanelFull
-( const DistMatrix<F>& A, 
+( const DistMatrix<F>& A,
         DistMatrix<F,MD,STAR>& d,
   const DistMatrix<F,MC,STAR>& X,
   const DistMatrix<F,MR,STAR>& Y )
@@ -102,7 +102,7 @@ LDLPivot PanelFull
     LDLPivot pivot;
     pivot.nb = 1;
     pivot.from[0] = diagMax.index;
-    
+
     return pivot;
 }
 
@@ -144,7 +144,7 @@ void PivotedLowerUnblocked( Matrix<F>& A, Permutation& P )
         const Base<F> delta11 = Sqrt(ABR.GetRealPart(0,0));
         const Base<F> delta11Inv = Base<F>(1)/delta11;
         ABR.Set(0,0,delta11);
-        a21 *= delta11Inv;
+        Scale(delta11Inv, a21);
 
         // A22 -= a21 a21'
         Her( LOWER, F(-1), a21, A22 );
@@ -193,7 +193,7 @@ void PivotedLowerUnblocked
         const Base<F> delta11 = Sqrt(ABR.GetRealPart(0,0));
         const Base<F> delta11Inv = Base<F>(1)/delta11;
         ABR.Set(0,0,delta11);
-        a21 *= delta11Inv;
+        Scale(delta11Inv, a21);
 
         // A22 -= a21 a21'
         Her( LOWER, F(-1), a21, A22 );
@@ -205,7 +205,7 @@ void PivotedLowerUnblocked
 template<typename F>
 void PivotedLowerPanel
 ( Matrix<F>& AFull,
-  Permutation& PFull, 
+  Permutation& PFull,
   Matrix<F>& X,
   Matrix<F>& Y,
   Int bsize,
@@ -243,7 +243,7 @@ void PivotedLowerPanel
         auto y21 = Y( ind2, ind1 );
         auto YB0 = Y( indB, ind0 );
 
-        // Determine the pivot 
+        // Determine the pivot
         const auto pivot = pivot::PanelFull( ABR, dB, XB0, YB0 );
         const Int from = k + pivot.from[0];
 
@@ -262,7 +262,7 @@ void PivotedLowerPanel
         const Base<F> delta11 = Sqrt(A.GetRealPart(k,k));
         const Base<F> delta11Inv = Base<F>(1)/delta11;
         A.SetRealPart(k,k,delta11);
-        a21 *= delta11Inv;
+        Scale(delta11Inv, a21);
 
         // Store x21 := a21 and y21 := conj(a21)
         Conjugate( a21, y21 );
@@ -333,7 +333,7 @@ void PivotedLowerPanel
         const Base<F> delta11 = Sqrt(A.GetRealPart(k,k));
         const Base<F> delta11Inv = Base<F>(1)/delta11;
         A.SetRealPart(k,k,delta11);
-        a21 *= delta11Inv;
+        Scale(delta11Inv, a21);
 
         // Store x21 := a21 and y21 := conj(a21)
         Conjugate( a21, y21 );

--- a/src/lapack_like/factor/Cholesky/PivotedUpperVariant3.hpp
+++ b/src/lapack_like/factor/Cholesky/PivotedUpperVariant3.hpp
@@ -2,8 +2,8 @@
    Copyright (c) 2009-2016, Jack Poulson
    All rights reserved.
 
-   This file is part of Elemental and is under the BSD 2-Clause License, 
-   which can be found in the LICENSE file in the root directory, or at 
+   This file is part of Elemental and is under the BSD 2-Clause License,
+   which can be found in the LICENSE file in the root directory, or at
    http://opensource.org/licenses/BSD-2-Clause
 */
 #ifndef EL_CHOLESKY_PIVOTED_UPPER_VARIANT3_HPP
@@ -51,7 +51,7 @@ void PivotedUpperUnblocked( Matrix<F>& A, Permutation& P )
         const Base<F> delta11 = Sqrt(ABR.GetRealPart(0,0));
         const Base<F> delta11Inv = Base<F>(1)/delta11;
         ABR.Set(0,0,delta11);
-        a12 *= delta11Inv;
+        Scale(delta11Inv, a12);
 
         // A22 := A22 - a12' a12
         // NOTE: This is silly, but currently necessary
@@ -91,7 +91,7 @@ void PivotedUpperUnblocked
         auto A22 = A( ind2, ind2 );
         auto ABR = A( indB, indR );
 
-        // Determine the pivot 
+        // Determine the pivot
         const LDLPivot pivot = pivot::Full( ABR );
 
         // Apply the pivot
@@ -103,7 +103,7 @@ void PivotedUpperUnblocked
         const Base<F> delta11 = Sqrt(ABR.GetRealPart(0,0));
         const Base<F> delta11Inv = Base<F>(1)/delta11;
         ABR.Set(0,0,delta11);
-        a12 *= delta11Inv;
+        Scale(delta11Inv, a12);
 
         // A22 := A22 - a12' a12
         // NOTE: This is silly, but currently necessary
@@ -118,7 +118,7 @@ void PivotedUpperUnblocked
 template<typename F>
 void PivotedUpperPanel
 ( Matrix<F>& AFull,
-  Permutation& PFull, 
+  Permutation& PFull,
   Matrix<F>& X,
   Matrix<F>& Y,
   Int bsize,
@@ -156,7 +156,7 @@ void PivotedUpperPanel
         auto y21 = Y( ind2, ind1 );
         auto YB0 = Y( indB, ind0 );
 
-        // Determine the pivot 
+        // Determine the pivot
         const auto pivot = pivot::PanelFull( ABR, dB, XB0, YB0 );
         const Int from = k + pivot.from[0];
 
@@ -175,7 +175,7 @@ void PivotedUpperPanel
         const Base<F> delta11 = Sqrt(A.GetRealPart(k,k));
         const Base<F> delta11Inv = Base<F>(1)/delta11;
         A.Set(k,k,delta11);
-        a12 *= delta11Inv;
+        Scale(delta11Inv, a12);
 
         // Store x21 := a12' and y21 := a12^T
         Adjoint( a12, x21 );
@@ -247,7 +247,7 @@ PivotedUpperPanel
         const Base<F> delta11 = Sqrt(A.GetRealPart(k,k));
         const Base<F> delta11Inv = Base<F>(1)/delta11;
         A.Set(k,k,delta11);
-        a12 *= delta11Inv;
+        Scale(delta11Inv, a12);
 
         // Store x21 := a12' and y21 := a12^T
         Adjoint( a12, x21 );

--- a/src/lapack_like/factor/Cholesky/UpperMod.hpp
+++ b/src/lapack_like/factor/Cholesky/UpperMod.hpp
@@ -61,10 +61,10 @@ void UpperUpdate( Matrix<F>& U, Matrix<F>& V )
         upsilon11 = -upsilon11;
         Conjugate( u12, z12 );
         Gemv( NORMAL, F(1), V2, v1, F(1), z12 );
-        V2 *= -1;
+        Scale(-1, V2);
         Ger( Conj(tau), z12, v1, V2 );
         Conjugate( z12 );
-        u12 *= -1;
+        Scale(-1, u12);
         Axpy( tau, z12, u12 );
     }
 }
@@ -133,10 +133,10 @@ void UpperUpdate
         LocalGemv( NORMAL, F(1), V2, v1_STAR_MR, F(0), b12_STAR_MC );
         El::AllReduce( b12_STAR_MC, V2.RowComm() );
         z12_STAR_MC += b12_STAR_MC;
-        V2 *= -1;
+        Scale(-1, V2);
         LocalGer( Conj(tau), z12_STAR_MC, v1_STAR_MR, V2 );
         Conjugate( z12_STAR_MC );
-        u12 *= -1;
+        Scale(-1, u12);
         Axpy( tau, z12_STAR_MC, u12 );
     }
 }
@@ -186,8 +186,8 @@ void UpperDowndate( Matrix<F>& U, Matrix<F>& V )
         upsilon11 = -upsilon11;
         Conjugate( u12, z12 );
         Gemv( NORMAL, F(-1), V2, v1, F(1), z12 );
-        u12 *= -1;
-        V2 *= -1;
+        Scale(-1, u12);
+        Scale(-1, V2);
         Ger( F(1)/tau, z12, v1, V2 );
         Conjugate( z12 );
         Axpy( F(1)/tau, z12, u12 );
@@ -257,8 +257,8 @@ void UpperDowndate
         LocalGemv( NORMAL, F(-1), V2, v1_STAR_MR, F(0), b12_STAR_MC );
         El::AllReduce( b12_STAR_MC, V2.RowComm() );
         z12_STAR_MC += b12_STAR_MC;
-        u12 *= -1;
-        V2 *= -1;
+        Scale(-1, u12);
+        Scale(-1, V2);
         LocalGer( F(1)/tau, z12_STAR_MC, v1_STAR_MR, V2 );
         Conjugate( z12_STAR_MC );
         Axpy( F(1)/tau, z12_STAR_MC, u12 );
@@ -276,12 +276,12 @@ void UpperMod( Matrix<F>& U, Base<F> alpha, Matrix<F>& V )
         return;
     else if( alpha > Real(0) )
     {
-        V *= Sqrt(alpha);
+        Scale(Sqrt(alpha), V);
         mod::UpperUpdate( U, V );
     }
     else
     {
-        V *= Sqrt(-alpha);
+        Scale(Sqrt(-alpha), V);
         mod::UpperDowndate( U, V );
     }
 }

--- a/src/lapack_like/factor/Cholesky/UpperVariant3.hpp
+++ b/src/lapack_like/factor/Cholesky/UpperVariant3.hpp
@@ -12,77 +12,85 @@
 namespace El {
 namespace cholesky {
 
+#ifdef HYDROGEN_HAVE_GPU
+template <typename F>
+void UpperVariant3Unblocked(Matrix<F, Device::GPU>& A)
+{
+    RuntimeError("Function not yet implemented.");
+}
+#endif // HYDROGEN_HAVE_GPU
+
 template<typename F>
-void UpperVariant3Unblocked( Matrix<F>& A )
+void UpperVariant3Unblocked(Matrix<F>& A)
 {
     EL_DEBUG_CSE
     EL_DEBUG_ONLY(
-      if( A.Height() != A.Width() )
+      if(A.Height() != A.Width())
           LogicError("Can only compute Cholesky factor of square matrices");
-    )
+   )
     typedef Base<F> Real;
     const Int n = A.Height();
     const Int ALDim = A.LDim();
-    for( Int j=0; j<n; ++j )
+    for(Int j=0; j<n; ++j)
     {
         Real alpha11 = RealPart(A(j,j));
-        if( alpha11 <= Real(0) )
+        if(alpha11 <= Real(0))
             throw NonHPDMatrixException("A was not numerically HPD");
-        alpha11 = Sqrt( alpha11 );
+        alpha11 = Sqrt(alpha11);
         A(j,j) = alpha11;
 
         const Int a12Width = n-(j+1);
         F* a12 = A.Buffer(j  ,j+1);
         F* A22 = A.Buffer(j+1,j+1);
 
-        blas::Scal( a12Width, Real(1)/alpha11, a12, ALDim );
+        blas::Scal(a12Width, Real(1)/alpha11, a12, ALDim);
 
-        for( Int k=0; k<a12Width; ++k )
+        for(Int k=0; k<a12Width; ++k)
             A(j,j+1+k) = Conj(A(j,j+1+k));
-        blas::Her( 'U', a12Width, -Real(1), a12, ALDim, A22, ALDim );
-        for( Int k=0; k<a12Width; ++k )
+        blas::Her('U', a12Width, -Real(1), a12, ALDim, A22, ALDim);
+        for(Int k=0; k<a12Width; ++k)
             A(j,j+1+k) = Conj(A(j,j+1+k));
     }
 }
 
-template<typename F>
-void UpperVariant3Blocked( Matrix<F>& A )
+template<typename F, Device D>
+void UpperVariant3Blocked(Matrix<F, D>& A)
 {
     EL_DEBUG_CSE
     EL_DEBUG_ONLY(
-      if( A.Height() != A.Width() )
+      if(A.Height() != A.Width())
           LogicError("Can only compute Cholesky factor of square matrices");
-    )
+   )
     const Int n = A.Height();
     const Int bsize = Blocksize();
-    for( Int k=0; k<n; k+=bsize )
+    for(Int k=0; k<n; k+=bsize)
     {
         const Int nb = Min(bsize,n-k);
 
-        const Range<Int> ind1( k,    k+nb ),
-                         ind2( k+nb, n    );
+        const Range<Int> ind1(k,    k+nb),
+                         ind2(k+nb, n   );
 
-        auto A11 = A( ind1, ind1 );
-        auto A12 = A( ind1, ind2 );
-        auto A22 = A( ind2, ind2 );
+        auto A11 = A(ind1, ind1);
+        auto A12 = A(ind1, ind2);
+        auto A22 = A(ind2, ind2);
 
-        cholesky::UpperVariant3Unblocked( A11 );
-        Trsm( LEFT, UPPER, ADJOINT, NON_UNIT, F(1), A11, A12 );
-        Herk( UPPER, ADJOINT, Base<F>(-1), A12, Base<F>(1), A22 );
+        cholesky::UpperVariant3Unblocked(A11);
+        Trsm(LEFT, UPPER, ADJOINT, NON_UNIT, F(1), A11, A12);
+        Herk(UPPER, ADJOINT, Base<F>(-1), A12, Base<F>(1), A22);
     }
 }
 
 template<typename F>
-void UpperVariant3Blocked( AbstractDistMatrix<F>& APre )
+void UpperVariant3Blocked(AbstractDistMatrix<F>& APre)
 {
     EL_DEBUG_CSE
     EL_DEBUG_ONLY(
-      if( APre.Height() != APre.Width() )
+      if(APre.Height() != APre.Width())
           LogicError("Can only compute Cholesky factor of square matrices");
-    )
+   )
     const Grid& grid = APre.Grid();
 
-    DistMatrixReadWriteProxy<F,F,MC,MR> AProx( APre );
+    DistMatrixReadWriteProxy<F,F,MC,MR> AProx(APre);
     auto& A = AProx.Get();
 
     DistMatrix<F,STAR,STAR> A11_STAR_STAR(grid);
@@ -92,32 +100,32 @@ void UpperVariant3Blocked( AbstractDistMatrix<F>& APre )
 
     const Int n = A.Height();
     const Int bsize = Blocksize();
-    for( Int k=0; k<n; k+=bsize )
+    for(Int k=0; k<n; k+=bsize)
     {
         const Int nb = Min(bsize,n-k);
 
-        const Range<Int> ind1( k,    k+nb ),
-                         ind2( k+nb, n    );
+        const Range<Int> ind1(k,    k+nb),
+                         ind2(k+nb, n   );
 
-        auto A11 = A( ind1, ind1 );
-        auto A12 = A( ind1, ind2 );
-        auto A22 = A( ind2, ind2 );
+        auto A11 = A(ind1, ind1);
+        auto A12 = A(ind1, ind2);
+        auto A22 = A(ind2, ind2);
 
         A11_STAR_STAR = A11;
-        Cholesky( UPPER, A11_STAR_STAR );
+        Cholesky(UPPER, A11_STAR_STAR);
         A11 = A11_STAR_STAR;
 
-        A12_STAR_VR.AlignWith( A22 );
+        A12_STAR_VR.AlignWith(A22);
         A12_STAR_VR = A12;
-        LocalTrsm
-        ( LEFT, UPPER, ADJOINT, NON_UNIT, F(1), A11_STAR_STAR, A12_STAR_VR );
+        LocalTrsm(
+            LEFT, UPPER, ADJOINT, NON_UNIT, F(1), A11_STAR_STAR, A12_STAR_VR);
 
-        A12_STAR_MC.AlignWith( A22 );
+        A12_STAR_MC.AlignWith(A22);
         A12_STAR_MC = A12_STAR_VR;
-        A12_STAR_MR.AlignWith( A22 );
+        A12_STAR_MR.AlignWith(A22);
         A12_STAR_MR = A12_STAR_VR;
-        LocalTrrk
-        ( UPPER, ADJOINT, F(-1), A12_STAR_MC, A12_STAR_MR, F(1), A22 );
+        LocalTrrk(
+            UPPER, ADJOINT, F(-1), A12_STAR_MC, A12_STAR_MR, F(1), A22);
         A12 = A12_STAR_MR;
     }
 }

--- a/src/lapack_like/factor/Cholesky/UpperVariant3.hpp
+++ b/src/lapack_like/factor/Cholesky/UpperVariant3.hpp
@@ -16,7 +16,7 @@ namespace cholesky {
 template <typename F>
 void UpperVariant3Unblocked(Matrix<F, Device::GPU>& A)
 {
-    RuntimeError("Function not yet implemented.");
+    LocalGPUCholesky(FillMode::UPPER_TRIANGLE, A);
 }
 #endif // HYDROGEN_HAVE_GPU
 


### PR DESCRIPTION
Calls legacy code on CPU; calls cuSOLVER for local GPU factorizations.

TODO:

- [x] Complete rocSolver integration for the ROCm stack.
- [x] Test GPU code.

EDIT: We have decided that adding straightforward LAPACK POTRF bindings for CPU matrices when we have LAPACK support is best left for future work.