### PR TITLE
Finish some outstanding cuBLAS implementation details

### DIFF
--- a/include/hydrogen/blas/BLAS_Common.hpp
+++ b/include/hydrogen/blas/BLAS_Common.hpp
@@ -138,6 +138,16 @@ namespace gpu_blas
 {
 /** @brief Set the pointer mode of the underlying library. */
 void SetPointerMode(PointerMode mode);
+
+/** @brief Request that the underlying library use specialized tensor
+ *         instructions.
+ *
+ *  This is not a guarantee that such operations are available or will
+ *  be used. However, if the library/hardware does expose such
+ *  features, this will suggest to the library that they be used
+ *  whenever possible.
+ */
+void RequestTensorOperations();
 }
 }// namespace hydrogen
 #endif // HYDROGEN_BLAS_COMMON_HPP_

--- a/include/hydrogen/blas/GPU_BLAS_decl.hpp
+++ b/include/hydrogen/blas/GPU_BLAS_decl.hpp
@@ -306,7 +306,7 @@ void Dot(SizeT num_entries,
  *  @param num_entries The number of entries in X.
  *  @param X The vector (device memory).
  *  @param stride_X The stride of X.
- *  @param result The result of the dot product (host or device memory).
+ *  @param result The result of the norm (host or device memory).
  *  @param[in] syncinfo The synchronization information for this
  *                      operation.
  *
@@ -537,7 +537,6 @@ void GemmStridedBatched(
     T* C, SizeT ldc, StrideT strideC,
     SizeT batchCount,
     SyncInfo<Device::GPU> const& syncinfo);
-
 
 ///@}
 /** @name BLAS-like Extension Routines */

--- a/include/hydrogen/device/gpu/cuda/cuBLAS_API.hpp
+++ b/include/hydrogen/device/gpu/cuda/cuBLAS_API.hpp
@@ -29,13 +29,13 @@ namespace cublas
              int n,                             \
              ScalarType const* X, int incx,     \
              ScalarType const* Y, int incy,     \
-             ScalarType& output)
+             ScalarType* output)
 
 #define ADD_NRM2_DECL(ScalarType)               \
     void Nrm2(cublasHandle_t handle,            \
               int n,                            \
               ScalarType const* X, int incx,    \
-              ScalarType& output)
+              ScalarType* output)
 
 #define ADD_SCALE_DECL(ScalarType)                       \
     void Scale(cublasHandle_t handle,                    \

--- a/src/hydrogen/device/cuBLAS.cpp
+++ b/src/hydrogen/device/cuBLAS.cpp
@@ -155,5 +155,12 @@ void SetPointerMode(PointerMode mode)
                               ? CUBLAS_POINTER_MODE_HOST
                               : CUBLAS_POINTER_MODE_DEVICE)));
 }
+void RequestTensorOperations()
+{
+    H_CHECK_CUBLAS(
+        cublasSetMathMode(cublas::GetLibraryHandle(),
+                          CUBLAS_TENSOR_OP_MATH));
+}
+
 }// namespace gpu_blas
 }// namespace hydrogen

--- a/src/hydrogen/device/rocBLAS.cpp
+++ b/src/hydrogen/device/rocBLAS.cpp
@@ -143,6 +143,11 @@ void SetPointerMode(PointerMode mode)
                                   ? rocblas_pointer_mode_host
                                   : rocblas_pointer_mode_device)));
 }
+void RequestTensorOperations()
+{
+// Nothing to do here.
+}
+
 }// namespace gpu_blas
 
 }// namespace hydrogen


### PR DESCRIPTION
This support should carry over to rocBLAS as well, but this should be verified.

These changes are needed (1) because the APIs already exist with missing implementations and (2) to support LBANN's transition to this API.