### PR TITLE
Use "simd collapse(2)" pragmas throughout code

### DIFF
--- a/include/El/blas_like/level1/Axpy.hpp
+++ b/include/El/blas_like/level1/Axpy.hpp
@@ -82,10 +82,9 @@ void Axpy(S alphaS, const Matrix<T,Device::CPU>& X, Matrix<T,Device::CPU>& Y)
         }
         else
         {
-            EL_PARALLEL_FOR
+            EL_SIMD_COLLAPSE2
             for(Int j=0; j<nX; ++j)
             {
-                EL_SIMD
                 for(Int i=0; i<mX; ++i)
                 {
                     YBuf[i+j*ldY] += alpha*XBuf[i+j*ldX];

--- a/include/El/blas_like/level1/EntrywiseMap.hpp
+++ b/include/El/blas_like/level1/EntrywiseMap.hpp
@@ -42,10 +42,9 @@ void EntrywiseMap(AbstractMatrix<T>& A, function<T(const T&)> func)
     }
     else
     {
-        EL_PARALLEL_FOR
+        EL_SIMD_COLLAPSE2
         for(Int j=0; j<n; ++j)
         {
-            EL_SIMD
             for(Int i=0; i<m; ++i)
             {
                 ABuf[i+j*ALDim] = func(ABuf[i+j*ALDim]);
@@ -74,10 +73,9 @@ void EntrywiseMap
     T* BBuf = B.Buffer();
     const Int ALDim = A.LDim();
     const Int BLDim = B.LDim();
-    EL_PARALLEL_FOR
+    EL_SIMD_COLLAPSE2
     for(Int j=0; j<n; ++j)
     {
-        EL_SIMD
         for(Int i=0; i<m; ++i)
         {
             BBuf[i+j*BLDim] = func(ABuf[i+j*ALDim]);

--- a/include/El/blas_like/level1/Hadamard.hpp
+++ b/include/El/blas_like/level1/Hadamard.hpp
@@ -67,10 +67,9 @@ void Hadamard(AbstractMatrix<T> const& A, AbstractMatrix<T> const& B,
         }
         else
         {
-            EL_PARALLEL_FOR
+            EL_SIMD_COLLAPSE2
             for( Int j=0; j<width; ++j )
             {
-                EL_SIMD
                 for( Int i=0; i<height; ++i )
                 {
                     CBuf[i+j*CLDim] = ABuf[i+j*ALDim] * BBuf[i+j*BLDim];

--- a/include/El/blas_like/level1/IndexDependentFill.hpp
+++ b/include/El/blas_like/level1/IndexDependentFill.hpp
@@ -32,10 +32,9 @@ void IndexDependentFill( Matrix<T>& A, function<T(Int,Int)> func )
     }
     else
     {
-        EL_PARALLEL_FOR
+        EL_SIMD_COLLAPSE2
         for( Int j=0; j<n; ++j )
         {
-            EL_SIMD
             for( Int i=0; i<m; ++i )
             {
                 ABuf[i+j*ALDim] = func(i,j);
@@ -69,10 +68,9 @@ void IndexDependentFill
     }
     else
     {
-        EL_PARALLEL_FOR
+        EL_SIMD_COLLAPSE2
         for( Int jLoc=0; jLoc<nLoc; ++jLoc )
         {
-            EL_SIMD
             for( Int iLoc=0; iLoc<mLoc; ++iLoc )
             {
                 const Int i = A.GlobalRow(iLoc);

--- a/include/El/blas_like/level1/IndexDependentMap.hpp
+++ b/include/El/blas_like/level1/IndexDependentMap.hpp
@@ -32,10 +32,9 @@ void IndexDependentMap( Matrix<T>& A, function<T(Int,Int,const T&)> func )
     }
     else
     {
-        EL_PARALLEL_FOR
+        EL_SIMD_COLLAPSE2
         for( Int j=0; j<n; ++j )
         {
-            EL_SIMD
             for( Int i=0; i<m; ++i )
             {
                 ABuf[i+j*ALDim] = func(i,j,ABuf[i+j*ALDim]);
@@ -87,10 +86,9 @@ void IndexDependentMap
     }
     else
     {
-        EL_PARALLEL_FOR
+        EL_SIMD_COLLAPSE2
         for( Int jLoc=0; jLoc<nLoc; ++jLoc )
         {
-            EL_SIMD
             for( Int iLoc=0; iLoc<mLoc; ++iLoc )
             {
                 const Int i = A.GlobalRow(iLoc);
@@ -127,10 +125,9 @@ void IndexDependentMap
     }
     else
     {
-        EL_PARALLEL_FOR
+        EL_SIMD_COLLAPSE2
         for( Int j=0; j<n; ++j )
         {
-            EL_SIMD
             for( Int i=0; i<m; ++i )
             {
                 BBuf[i+j*BLDim] = func(i,j,ABuf[i+j*ALDim]);
@@ -170,10 +167,9 @@ void IndexDependentMap
     }
     else
     {
-        EL_PARALLEL_FOR
+        EL_SIMD_COLLAPSE2
         for( Int jLoc=0; jLoc<nLoc; ++jLoc )
         {
-            EL_SIMD
             for( Int iLoc=0; iLoc<mLoc; ++iLoc )
             {
                 const Int i = A.GlobalRow(iLoc);

--- a/include/El/core/imports/omp.hpp
+++ b/include/El/core/imports/omp.hpp
@@ -26,8 +26,10 @@
 # endif
 # ifdef EL_HAVE_OMP_SIMD
 #  define EL_SIMD _Pragma("omp simd")
+#  define EL_SIMD_COLLAPSE2 _Pragma("omp simd collapse(2)")
 # else
 #  define EL_SIMD
+#  define EL_SIMD_COLLAPSE2
 # endif
 #else
 # define EL_PARALLEL_FOR


### PR DESCRIPTION
I'm not sure we want to merge this into the main branch without profiling to determine if it's a pessimization, neutral or a win. It cleans up some clang warnings about failure to vectorize, but in theory the original structure should be better.