### PR TITLE
Avoid unnecessary memory allocation in scatter function

### DIFF
--- a/include/El/blas_like/level1/Copy/Scatter.hpp
+++ b/include/El/blas_like/level1/Copy/Scatter.hpp
@@ -119,7 +119,7 @@ void Scatter
     if (B.Participating())
     {
         if (A.Participating())
-            B.Matrix() = A.LockedMatrix();
+            El::Copy(A.LockedMatrix(), B.Matrix());
         El::Broadcast(B, A.CrossComm(), A.Root());
     }
 }
@@ -135,7 +135,7 @@ void Scatter
     if (B.Participating())
     {
         if (A.Participating())
-            B.Matrix() = A.LockedMatrix();
+            El::Copy(A.LockedMatrix(), B.Matrix());
         El::Broadcast(B, A.CrossComm(), A.Root());
     }
 }


### PR DESCRIPTION
When calling `El::Copy` from a `[CIRC,CIRC]` to `[STAR,STAR]` matrix, I observe that we always reallocate the output buffer. With this PR, it avoids reallocating if the output matrix already has the right dimensions.