### PR TITLE
Remove raw MPI call from TranslateBetweenGrids helper function

### DIFF
--- a/include/El/blas_like/level1/Copy/TranslateBetweenGrids.hpp
+++ b/include/El/blas_like/level1/Copy/TranslateBetweenGrids.hpp
@@ -949,14 +949,10 @@ void TranslateBetweenGridsScatterOptComm
     for(Int localDataRankA = 0; localDataRankA < int(rowLCM/sizeB); localDataRankA++)
     {
 
-        MPI_Scatter((void *)sendBuf, sendCounts, mpi::TypeMap<T>(), (void *)recvTransposedMatrix.Buffer(), sendCounts, mpi::TypeMap<T>(), localDataRankA, ScatterComm.GetMPIComm());
-
-         // mpi::Scatter(sendBuf, sendCounts, recvTransposedMatrix.Buffer(), sendCounts, localDataRankA, ScatterComm,
-         //        syncGeneral);
-
-        Synchronize(syncGeneral);
-
-
+        mpi::Scatter(
+          sendBuf, sendCounts,
+          recvTransposedMatrix.Buffer(), sendCounts,
+          localDataRankA, ScatterComm, syncGeneral);
 
         for(Int childLayerSubGrid = 0; childLayerSubGrid < numMatricesInSubGrid; ++childLayerSubGrid)
         {


### PR DESCRIPTION
I have observed a race condition when performing sub-grid parallelism in LBANN on GPUs. The culprit seems to be this direct call to `MPI_Scatter`, which is not synchronized with the correct CUDA stream. Switching to Elemental's MPI wrapper function fixes the race condition for me.