### PR TITLE
Remove FP16 from the ETI for eigensolvers.

### DIFF
--- a/src/blas_like/level2/Ger.cpp
+++ b/src/blas_like/level2/Ger.cpp
@@ -161,7 +161,7 @@ void LocalGer
 #define EL_ENABLE_QUAD
 #define EL_ENABLE_BIGINT
 #define EL_ENABLE_BIGFLOAT
-#define EL_ENABLE_HALF
+/*#undef EL_ENABLE_HALF*/
 #include <El/macros/Instantiate.h>
 
 } // namespace El

--- a/src/blas_like/level2/Hemv.cpp
+++ b/src/blas_like/level2/Hemv.cpp
@@ -54,7 +54,7 @@ void Hemv
 #define EL_ENABLE_QUAD
 #define EL_ENABLE_BIGINT
 #define EL_ENABLE_BIGFLOAT
-#define EL_ENABLE_HALF
+/*#undef EL_ENABLE_HALF*/
 #include <El/macros/Instantiate.h>
 
 } // namespace El

--- a/src/blas_like/level2/Her2.cpp
+++ b/src/blas_like/level2/Her2.cpp
@@ -49,7 +49,7 @@ void Her2
 #define EL_ENABLE_QUAD
 #define EL_ENABLE_BIGINT
 #define EL_ENABLE_BIGFLOAT
-#define EL_ENABLE_HALF
+/*#undef EL_ENABLE_HALF*/
 #include <El/macros/Instantiate.h>
 
 } // namespace El

--- a/src/blas_like/level2/Symv.cpp
+++ b/src/blas_like/level2/Symv.cpp
@@ -354,7 +354,7 @@ void LocalRowAccumulate
 #define EL_ENABLE_QUAD
 #define EL_ENABLE_BIGINT
 #define EL_ENABLE_BIGFLOAT
-#define EL_ENABLE_HALF
+/*#undef EL_ENABLE_HALF*/
 #include <El/macros/Instantiate.h>
 
 } // namespace El

--- a/src/blas_like/level2/Syr2.cpp
+++ b/src/blas_like/level2/Syr2.cpp
@@ -313,7 +313,7 @@ void Syr2
 #define EL_ENABLE_QUAD
 #define EL_ENABLE_BIGINT
 #define EL_ENABLE_BIGFLOAT
-#define EL_ENABLE_HALF
+/*#undef EL_ENABLE_HALF*/
 #include <El/macros/Instantiate.h>
 
 } // namespace El

--- a/src/lapack_like/condense/HermitianTridiag.cpp
+++ b/src/lapack_like/condense/HermitianTridiag.cpp
@@ -240,7 +240,7 @@ void ExplicitCondensed
 #define EL_ENABLE_QUADDOUBLE
 #define EL_ENABLE_QUAD
 #define EL_ENABLE_BIGFLOAT
-#define EL_ENABLE_HALF
+/*#undef EL_ENABLE_HALF*/
 #include <El/macros/Instantiate.h>
 
 } // namespace El

--- a/src/lapack_like/props/Norm/Infinity.cpp
+++ b/src/lapack_like/props/Norm/Infinity.cpp
@@ -140,7 +140,7 @@ Base<Ring> HermitianTridiagInfinityNorm
 #define EL_ENABLE_QUADDOUBLE
 #define EL_ENABLE_QUAD
 #define EL_ENABLE_BIGFLOAT
-#define EL_ENABLE_HALF
+/*#undef EL_ENABLE_HALF*/
 #include <El/macros/Instantiate.h>
 
 } // namespace El

--- a/src/lapack_like/props/Norm/Max.cpp
+++ b/src/lapack_like/props/Norm/Max.cpp
@@ -149,7 +149,7 @@ SymmetricMaxNorm( UpperOrLower uplo, const AbstractDistMatrix<Ring>& A )
 #define EL_ENABLE_QUAD
 #define EL_ENABLE_BIGINT
 #define EL_ENABLE_BIGFLOAT
-#define EL_ENABLE_HALF
+/*#undef EL_ENABLE_HALF*/
 #include <El/macros/Instantiate.h>
 
 } // namespace El

--- a/src/lapack_like/props/Norm/One.cpp
+++ b/src/lapack_like/props/Norm/One.cpp
@@ -284,7 +284,7 @@ Base<Ring> HermitianTridiagOneNorm
 #define EL_ENABLE_QUADDOUBLE
 #define EL_ENABLE_QUAD
 #define EL_ENABLE_BIGFLOAT
-#define EL_ENABLE_HALF
+/*#undef EL_ENABLE_HALF*/
 #include <El/macros/Instantiate.h>
 
 } // namespace El

--- a/src/lapack_like/reflect/ApplyPacked.cpp
+++ b/src/lapack_like/reflect/ApplyPacked.cpp
@@ -214,7 +214,7 @@ void ApplyPackedReflectors
 #define EL_ENABLE_QUADDOUBLE
 #define EL_ENABLE_QUAD
 #define EL_ENABLE_BIGFLOAT
-#define EL_ENABLE_HALF
+/*#undef EL_ENABLE_HALF*/
 #include <El/macros/Instantiate.h>
 
 } // namespace El

--- a/src/lapack_like/reflect/Householder.cpp
+++ b/src/lapack_like/reflect/Householder.cpp
@@ -220,7 +220,7 @@ F RightReflector( F& chi, AbstractDistMatrix<F>& x )
 #define EL_ENABLE_QUADDOUBLE
 #define EL_ENABLE_QUAD
 #define EL_ENABLE_BIGFLOAT
-#define EL_ENABLE_HALF
+/*#undef EL_ENABLE_HALF*/
 #include <El/macros/Instantiate.h>
 
 } // namespace El

--- a/src/lapack_like/spectral/CubicSecular.cpp
+++ b/src/lapack_like/spectral/CubicSecular.cpp
@@ -322,7 +322,7 @@ CubicSecular
 #define EL_ENABLE_QUADDOUBLE
 #define EL_ENABLE_QUAD
 #define EL_ENABLE_BIGFLOAT
-#define EL_ENABLE_HALF
+/*#undef EL_ENABLE_HALF*/
 
 #include <El/macros/Instantiate.h>
 

--- a/src/lapack_like/spectral/HermitianEig.cpp
+++ b/src/lapack_like/spectral/HermitianEig.cpp
@@ -1190,7 +1190,7 @@ HermitianEig
 #define EL_ENABLE_QUADDOUBLE
 #define EL_ENABLE_QUAD
 #define EL_ENABLE_BIGFLOAT
-#define EL_ENABLE_HALF
+/*#undef EL_ENABLE_HALF*/
 #include <El/macros/Instantiate.h>
 
 } // namespace El

--- a/src/lapack_like/spectral/HermitianTridiagEig.cpp
+++ b/src/lapack_like/spectral/HermitianTridiagEig.cpp
@@ -1669,7 +1669,7 @@ MRRRPostEstimate
 #define EL_ENABLE_DOUBLEDOUBLE
 #define EL_ENABLE_QUADDOUBLE
 #define EL_ENABLE_BIGFLOAT
-#define EL_ENABLE_HALF
+/*#undef EL_ENABLE_HALF*/
 #include <El/macros/Instantiate.h>
 
 } // namespace El

--- a/src/lapack_like/spectral/SecularEVD.cpp
+++ b/src/lapack_like/spectral/SecularEVD.cpp
@@ -1376,7 +1376,7 @@ SecularEVD
 #define EL_ENABLE_QUADDOUBLE
 #define EL_ENABLE_QUAD
 #define EL_ENABLE_BIGFLOAT
-#define EL_ENABLE_HALF
+/*#undef EL_ENABLE_HALF*/
 
 #include <El/macros/Instantiate.h>
 

--- a/src/lapack_like/util/Sort.cpp
+++ b/src/lapack_like/util/Sort.cpp
@@ -345,7 +345,7 @@ void MergeSortingPermutation
 #define EL_ENABLE_QUAD
 #define EL_ENABLE_BIGINT
 #define EL_ENABLE_BIGFLOAT
-#define EL_ENABLE_HALF
+/*#undef EL_ENABLE_HALF*/
 #include <El/macros/Instantiate.h>
 
 } // namespace El


### PR DESCRIPTION
I'm not opposed to such things, but it's not straightforward from a numerics nor a compilations standpoint. So I'm disabling it until a true need arises.