### PR TITLE
Serial eigensolver for GPU

### DIFF
--- a/include/El/blas_like/level1/Copy/TranslateBetweenGrids.hpp
+++ b/include/El/blas_like/level1/Copy/TranslateBetweenGrids.hpp
@@ -112,15 +112,6 @@ void TranslateBetweenGrids
     mpi::Translate(
         owningGroupA, sizeA, ranks.data(), viewingCommB, rankMap.data());
 
-    // Have each member of A's grid individually send to all numRow x numCol
-    // processes in order, while the members of this grid receive from all
-    // necessary processes at each step.
-    Int requiredMemory = 0;
-    if(inAGrid)
-        requiredMemory += maxSendSize;
-    if(inBGrid)
-        requiredMemory += maxSendSize;
-
     SyncInfo<D1> syncInfoA = SyncInfoFromMatrix(A.LockedMatrix());
     SyncInfo<D2> syncInfoB = SyncInfoFromMatrix(B.LockedMatrix());
 
@@ -3676,15 +3667,6 @@ void TranslateBetweenGridsAsync
     mpi::Translate(
         owningGroupA, sizeA, ranks.data(), viewingCommB, rankMap.data());
 
-    Int requiredMemory = 0;
-    if(inAGrid)
-        requiredMemory += maxSendSize;
-    if(inBGrid)
-        requiredMemory += maxSendSize;
-
-
-
-
     std::vector<simple_buffer<T,D1>> sendBufVector(numRowSends);
 
     for(Int i=0; i<numRowSends; ++i)
@@ -3969,12 +3951,6 @@ void TranslateBetweenGrids
     }
     mpi::Translate(
         owningGroupA, sizeA, ranks.data(), viewingCommB, rankMap.data());
-
-    Int requiredMemory = 0;
-    if(inAGrid)
-        requiredMemory += maxSendSize;
-    if(inBGrid)
-        requiredMemory += maxSendSize;
 
     simple_buffer<T,D1> send_buf(inAGrid ? maxSendSize : 0, syncInfoA);
     simple_buffer<T,D2> recv_buf(inBGrid ? maxSendSize : 0, syncInfoB);

--- a/include/El/blas_like/level1/CopyFromRoot.hpp
+++ b/include/El/blas_like/level1/CopyFromRoot.hpp
@@ -6,7 +6,7 @@ namespace El
 
 template<typename T>
 void CopyFromRoot(const Matrix<T>& A, DistMatrix<T,CIRC,CIRC>& B,
-                  bool includingViewers)
+                  bool includingViewers=false)
 {
     EL_DEBUG_CSE;
     if (B.CrossRank() != B.Root())
@@ -17,7 +17,7 @@ void CopyFromRoot(const Matrix<T>& A, DistMatrix<T,CIRC,CIRC>& B,
 }
 
 template<typename T>
-void CopyFromNonRoot(DistMatrix<T,CIRC,CIRC>& B, bool includingViewers)
+void CopyFromNonRoot(DistMatrix<T,CIRC,CIRC>& B, bool includingViewers=false)
 {
     EL_DEBUG_CSE;
     if (B.CrossRank() == B.Root())
@@ -27,7 +27,7 @@ void CopyFromNonRoot(DistMatrix<T,CIRC,CIRC>& B, bool includingViewers)
 
 template<typename T>
 void CopyFromRoot (const Matrix<T>& A, DistMatrix<T,CIRC,CIRC,BLOCK>& B,
-                   bool includingViewers)
+                   bool includingViewers=false)
 {
     EL_DEBUG_CSE;
     if (B.CrossRank() != B.Root())
@@ -38,7 +38,8 @@ void CopyFromRoot (const Matrix<T>& A, DistMatrix<T,CIRC,CIRC,BLOCK>& B,
 }
 
 template<typename T>
-void CopyFromNonRoot (DistMatrix<T,CIRC,CIRC,BLOCK>& B, bool includingViewers)
+void CopyFromNonRoot (DistMatrix<T,CIRC,CIRC,BLOCK>& B,
+                      bool includingViewers=false)
 {
     EL_DEBUG_CSE;
     if (B.CrossRank() == B.Root())

--- a/include/El/lapack_like/spectral.hpp
+++ b/include/El/lapack_like/spectral.hpp
@@ -426,12 +426,12 @@ struct HermitianEigInfo
 
 // Compute eigenvalues
 // -------------------
-template<typename Field>
+template<typename Field, El::Device D>
 HermitianEigInfo
 HermitianEig
 (       UpperOrLower uplo,
-        Matrix<Field>& A,
-        Matrix<Base<Field>>& w,
+        Matrix<Field, D>& A,
+        Matrix<Base<Field>, D>& w,
   const HermitianEigCtrl<Field>& ctrl=HermitianEigCtrl<Field>() );
 template<typename Field>
 HermitianEigInfo
@@ -443,13 +443,13 @@ HermitianEig
 
 // Compute eigenpairs
 // ------------------
-template<typename Field>
+template<typename Field, El::Device D>
 HermitianEigInfo
 HermitianEig
 (       UpperOrLower uplo,
-        Matrix<Field>& A,
-        Matrix<Base<Field>>& w,
-        Matrix<Field>& Q,
+        Matrix<Field, D>& A,
+        Matrix<Base<Field>, D>& w,
+        Matrix<Field, D>& Q,
   const HermitianEigCtrl<Field>& ctrl=HermitianEigCtrl<Field>() );
 template<typename Field>
 HermitianEigInfo

--- a/include/El/lapack_like/spectral.hpp
+++ b/include/El/lapack_like/spectral.hpp
@@ -426,12 +426,12 @@ struct HermitianEigInfo
 
 // Compute eigenvalues
 // -------------------
-template<typename Field, El::Device D>
+template<typename Field>
 HermitianEigInfo
 HermitianEig
 (       UpperOrLower uplo,
-        Matrix<Field, D>& A,
-        Matrix<Base<Field>, D>& w,
+        Matrix<Field, El::Device::CPU>& A,
+        Matrix<Base<Field>, El::Device::CPU>& w,
   const HermitianEigCtrl<Field>& ctrl=HermitianEigCtrl<Field>() );
 template<typename Field>
 HermitianEigInfo
@@ -443,13 +443,13 @@ HermitianEig
 
 // Compute eigenpairs
 // ------------------
-template<typename Field, El::Device D>
+template<typename Field>
 HermitianEigInfo
 HermitianEig
 (       UpperOrLower uplo,
-        Matrix<Field, D>& A,
-        Matrix<Base<Field>, D>& w,
-        Matrix<Field, D>& Q,
+        Matrix<Field, El::Device::CPU>& A,
+        Matrix<Base<Field>, El::Device::CPU>& w,
+        Matrix<Field, El::Device::CPU>& Q,
   const HermitianEigCtrl<Field>& ctrl=HermitianEigCtrl<Field>() );
 template<typename Field>
 HermitianEigInfo
@@ -460,6 +460,22 @@ HermitianEig
         AbstractDistMatrix<Field>& Q,
   const HermitianEigCtrl<Field>& ctrl=HermitianEigCtrl<Field>() );
 
+#ifdef HYDROGEN_HAVE_GPU
+template<typename Field>
+HermitianEigInfo
+HermitianEig
+(       UpperOrLower uplo,
+        Matrix<Field, El::Device::GPU>& A,
+        Matrix<Base<Field>, El::Device::GPU>& w,
+  const HermitianEigCtrl<Field>& ctrl=HermitianEigCtrl<Field>() );
+template <typename Field>
+HermitianEigInfo
+HermitianEig(UpperOrLower uplo,
+             Matrix<Field, El::Device::GPU>& A,
+             Matrix<Base<Field>, El::Device::GPU>& w,
+             Matrix<Field, El::Device::GPU>& Q,
+             const HermitianEigCtrl<Field>& ctrl = HermitianEigCtrl<Field>());
+#endif // HDYROGEN_HAVE_GPU
 namespace herm_eig {
 
 template<typename Real,

--- a/include/hydrogen/blas/BLAS_Common.hpp
+++ b/include/hydrogen/blas/BLAS_Common.hpp
@@ -38,6 +38,7 @@ enum class BLAS_Op
 
 enum class LAPACK_Op
 {
+    HEEV,
     POTRF,
 }; // enum class LAPACK_Op
 

--- a/include/hydrogen/blas/GPU_BLAS_decl.hpp
+++ b/include/hydrogen/blas/GPU_BLAS_decl.hpp
@@ -587,6 +587,24 @@ void Dgmm(SideMode side,
 namespace gpu_lapack
 {
 
+/** @brief Compute the eigenvalues and eigenvectors of A.
+ *
+ *  At this time, we only support the computation of values AND vectors.
+ *
+ *  @note Some workspace memory is allocated internally, using a
+ *        caching allocator when possible.
+ *  @note The "info" parameter to the solver routine is only checked
+ *        in DEBUG builds.
+ */
+template <typename T, typename SizeT>
+void HermitianEig(
+    FillMode uplo,
+    SizeT n,
+    T* A,
+    SizeT lda,
+    TmpBase<T>* W,
+    SyncInfo<Device::GPU> const& si);
+
 /** @brief Compute the Cholesky factorization of A.
  *
  *  This routine will allocate the properly-sized workspace and info

--- a/include/hydrogen/blas/GPU_BLAS_impl.hpp
+++ b/include/hydrogen/blas/GPU_BLAS_impl.hpp
@@ -1102,9 +1102,6 @@ void HermitianEigImpl(
     using NTP = MakePointer<NativeType<T>>;
     using RealNTP = MakePointer<NativeType<TmpBase<T>>>;
 
-    SyncManager mgr(GetDenseLibraryHandle(), si);
-    simple_buffer<gpu_lapack_impl::InfoT, Device::GPU> info(1, si);
-
     auto workspace_size = gpu_lapack_impl::GetHeevWorkspaceSize(
         GetDenseLibraryHandle(),
         ToNativeFillMode(uplo),
@@ -1112,7 +1109,10 @@ void HermitianEigImpl(
         reinterpret_cast<NTP>(A),
         ToSizeT(lda),
         reinterpret_cast<RealNTP>(W));
+
+    SyncManager mgr(GetDenseLibraryHandle(), si);
     simple_buffer<T, Device::GPU> workspace(workspace_size, si);
+    simple_buffer<gpu_lapack_impl::InfoT, Device::GPU> info(1, si);
 
     // NOTE: This excludes the "jobz" parameter -- we ALWAYS compute
     // the eigenvalues for now.

--- a/include/hydrogen/blas/GPU_BLAS_impl.hpp
+++ b/include/hydrogen/blas/GPU_BLAS_impl.hpp
@@ -1070,6 +1070,11 @@ namespace gpu_lapack
 {
 namespace details
 {
+
+#ifndef H_SYEVD_THRESHOLD
+#define H_SYEVD_THRESHOLD 2048
+#endif // H_SYEVD_THRESHOLD
+
 // These might be unique.
 using gpu_lapack_impl::ToSizeT;
 using gpu_lapack_impl::GetDenseLibraryHandle;
@@ -1083,18 +1088,82 @@ using gpu_blas_impl::ToNativeFillMode;
 using gpu_blas_impl::ToNativeSideMode;
 using gpu_blas_impl::ToNativeTransposeMode;
 
-template <typename T, typename SizeT, typename InfoT,
+template <typename T,
+          typename SizeT,
+          typename = EnableWhen<IsSupportedType<T, LAPACK_Op::HEEV>>>
+void HermitianEigImpl(
+    FillMode uplo,
+    SizeT n,
+    T* A,
+    SizeT lda,
+    TmpBase<T>* W,
+    SyncInfo<Device::GPU> const& si)
+{
+    using NTP = MakePointer<NativeType<T>>;
+    using RealNTP = MakePointer<NativeType<TmpBase<T>>>;
+
+    SyncManager mgr(GetDenseLibraryHandle(), si);
+    simple_buffer<gpu_lapack_impl::InfoT, Device::GPU> info(1, si);
+
+    auto workspace_size = gpu_lapack_impl::GetHeevWorkspaceSize(
+        GetDenseLibraryHandle(),
+        ToNativeFillMode(uplo),
+        ToSizeT(n),
+        reinterpret_cast<NTP>(A),
+        ToSizeT(lda),
+        reinterpret_cast<RealNTP>(W));
+    simple_buffer<T, Device::GPU> workspace(workspace_size, si);
+
+    // NOTE: This excludes the "jobz" parameter -- we ALWAYS compute
+    // the eigenvalues for now.
+    gpu_lapack_impl::Heev(
+        GetDenseLibraryHandle(),
+        ToNativeFillMode(uplo),
+        ToSizeT(n),
+        reinterpret_cast<NTP>(A),
+        ToSizeT(lda),
+        reinterpret_cast<RealNTP>(W),
+        reinterpret_cast<NTP>(workspace.data()),
+        workspace_size,
+        info.data());
+
+#ifndef EL_RELEASE
+    gpu_lapack_impl::InfoT host_info;
+    gpu::Copy1DToHost(info.data(), &host_info, 1, si);
+    Synchronize(si);
+    if (host_info > gpu_lapack_impl::InfoT(0))
+        throw std::runtime_error("HermitianEigImpl: Solver failed to converge.");
+    else if (host_info < gpu_lapack_impl::InfoT(0))
+        throw std::runtime_error("HermitianEigImpl: A parameter is bad.");
+#endif // EL_RELEASE
+}
+
+template <typename T, typename SizeT,
+          typename=EnableUnless<IsSupportedType<T,LAPACK_Op::HEEV>>,
+          typename=void>
+void HermitianEigImpl(
+    FillMode,
+    SizeT,
+    T*,
+    SizeT,
+    TmpBase<T>*,
+    SyncInfo<Device::GPU> const&)
+{
+    std::ostringstream oss;
+    oss << "No valid implementation of HermitianEig for T="
+        << TypeTraits<T>::Name();
+    throw std::logic_error(oss.str());
+}
+
+template <typename T, typename SizeT,
           typename=EnableWhen<IsSupportedType<T,LAPACK_Op::POTRF>>>
 void CholeskyFactorizeImpl(FillMode uplo,
                            SizeT n,
                            T* A, SizeT lda,
                            T* workspace, SizeT workspace_size,
-                           InfoT* info,
+                           gpu_lapack_impl::InfoT* info,
                            SyncInfo<Device::GPU> const& si)
 {
-    static_assert(IsSame<InfoT, gpu_lapack_impl::InfoT>::value,
-                  "Deduced InfoT must match gpu_lapack_impl::InfoT.");
-
     using NTP = MakePointer<NativeType<T>>;
 
     SyncManager mgr(GetDenseLibraryHandle(), si);
@@ -1193,6 +1262,18 @@ void CholeskyFactorizeImpl(FillMode const,
     throw std::logic_error(oss.str());
 }
 }// namespace details
+
+template <typename T, typename SizeT>
+void HermitianEig(
+    FillMode uplo,
+    SizeT n,
+    T* A,
+    SizeT lda,
+    TmpBase<T>* W,
+    SyncInfo<Device::GPU> const& si)
+{
+    details::HermitianEigImpl(uplo, n, A, lda, W, si);
+}
 
 template <typename T, typename SizeT>
 void CholeskyFactorize(FillMode uplo,

--- a/include/hydrogen/blas/GPU_BLAS_impl.hpp
+++ b/include/hydrogen/blas/GPU_BLAS_impl.hpp
@@ -1071,10 +1071,6 @@ namespace gpu_lapack
 namespace details
 {
 
-#ifndef H_SYEVD_THRESHOLD
-#define H_SYEVD_THRESHOLD 2048
-#endif // H_SYEVD_THRESHOLD
-
 // These might be unique.
 using gpu_lapack_impl::ToSizeT;
 using gpu_lapack_impl::GetDenseLibraryHandle;

--- a/include/hydrogen/device/gpu/cuda/cuSOLVER_API.hpp
+++ b/include/hydrogen/device/gpu/cuda/cuSOLVER_API.hpp
@@ -22,6 +22,26 @@ using DevicePtr = T*;
 
 using cusolver_int = int;
 
+template <typename T>
+struct RealTypeT
+{
+    using type = T;
+};
+
+template <>
+struct RealTypeT<cuComplex>
+    : RealTypeT<float>
+{
+};
+
+template <>
+struct RealTypeT<cuDoubleComplex>
+    : RealTypeT<double>
+{
+};
+
+template <typename T> using RealType = typename RealTypeT<T>::type;
+
 // Cholesky factorization
 #define ADD_POTRF_DECL(ScalarType)                      \
     cusolver_int GetPotrfWorkspaceSize(                 \
@@ -38,10 +58,33 @@ using cusolver_int = int;
         cusolver_int workspace_size,                    \
         DevicePtr<cusolver_int> devinfo)
 
-ADD_POTRF_DECL(float);
-ADD_POTRF_DECL(double);
-ADD_POTRF_DECL(cuComplex);
-ADD_POTRF_DECL(cuDoubleComplex);
+#define ADD_HEEV_DECL(ScalarType)                       \
+    cusolver_int GetHeevWorkspaceSize(                  \
+        cusolverDnHandle_t handle,                      \
+        cublasFillMode_t uplo,                          \
+        cusolver_int n,                                 \
+        DeviceArray<ScalarType> A,                      \
+        cusolver_int lda,                               \
+        DeviceArray<RealType<ScalarType>> W);           \
+    void Heev(                                          \
+        cusolverDnHandle_t handle,                      \
+        cublasFillMode_t uplo,                          \
+        cusolver_int n,                                 \
+        DeviceArray<ScalarType> A,                      \
+        cusolver_int lda,                               \
+        DeviceArray<RealType<ScalarType>> W,            \
+        DeviceArray<ScalarType> workspace,              \
+        cusolver_int workspace_size,                    \
+        DevicePtr<cusolver_int> devinfo)
+
+#define ADD_CUSOLVER_DECLS(ScalarType)          \
+    ADD_POTRF_DECL(ScalarType);                 \
+    ADD_HEEV_DECL(ScalarType)
+
+ADD_CUSOLVER_DECLS(float);
+ADD_CUSOLVER_DECLS(double);
+ADD_CUSOLVER_DECLS(cuComplex);
+ADD_CUSOLVER_DECLS(cuDoubleComplex);
 
 }// namespace cusolver
 }// namespace hydrogen

--- a/include/hydrogen/device/gpu/rocm/rocSOLVER_API.hpp
+++ b/include/hydrogen/device/gpu/rocm/rocSOLVER_API.hpp
@@ -5,47 +5,83 @@
 
 #include <rocsolver.h>
 
-namespace hydrogen
-{
-namespace rocsolver
-{
+namespace hydrogen {
+namespace rocsolver {
 
 // These are just for my own readability.
-template <typename T>
-using DeviceArray = T*;
+template <typename T> using DeviceArray = T*;
 
-template <typename T>
-using HostPtr = T*;
+template <typename T> using HostPtr = T*;
 
-template <typename T>
-using DevicePtr = T*;
+template <typename T> using DevicePtr = T*;
 
 using rocsolver_int = rocblas_int;
+
+template <typename T>
+struct RealTypeT
+{
+    using type = T;
+};
+
+template <>
+struct RealTypeT<rocblas_float_complex>
+    : RealTypeT<float>
+{
+};
+
+template <>
+struct RealTypeT<rocblas_double_complex>
+    : RealTypeT<double>
+{
+};
+
+template <typename T> using RealType = typename RealTypeT<T>::type;
 
 // Cholesky factorization
 //
 // Due to shortcomings in the rocSOLVER API, the workspace size will
 // always return zero, and the workspace pointer is unused.
-#define ADD_POTRF_DECL(ScalarType)                      \
-    rocblas_int GetPotrfWorkspaceSize(                  \
-        rocblas_handle handle,                          \
-        rocblas_fill uplo,                              \
-        rocblas_int n,                                  \
-        DeviceArray<ScalarType> A, rocblas_int lda);    \
-    void Potrf(                                         \
-        rocblas_handle handle,                          \
-        rocblas_fill uplo,                              \
-        rocblas_int n,                                  \
-        DeviceArray<ScalarType> A, rocblas_int lda,     \
-        DeviceArray<ScalarType> workspace,              \
-        rocblas_int workspace_size,                     \
-        DevicePtr<rocblas_int> devinfo)
+#define ADD_POTRF_DECL(ScalarType)                                             \
+    rocblas_int GetPotrfWorkspaceSize(rocblas_handle handle,                   \
+                                      rocblas_fill uplo,                       \
+                                      rocblas_int n,                           \
+                                      DeviceArray<ScalarType> A,               \
+                                      rocblas_int lda);                        \
+    void Potrf(rocblas_handle handle,                                          \
+               rocblas_fill uplo,                                              \
+               rocblas_int n,                                                  \
+               DeviceArray<ScalarType> A,                                      \
+               rocblas_int lda,                                                \
+               DeviceArray<ScalarType> workspace,                              \
+               rocblas_int workspace_size,                                     \
+               DevicePtr<rocblas_int> devinfo)
 
-ADD_POTRF_DECL(float);
-ADD_POTRF_DECL(double);
-ADD_POTRF_DECL(rocblas_float_complex);
-ADD_POTRF_DECL(rocblas_double_complex);
+#define ADD_HEEV_DECL(ScalarType)                                              \
+    rocblas_int GetHeevWorkspaceSize(rocblas_handle handle,                    \
+                                     rocblas_fill uplo,                        \
+                                     rocblas_int n,                            \
+                                     DeviceArray<ScalarType> A,                \
+                                     rocblas_int lda,                          \
+                                     DeviceArray<RealType<ScalarType>> W);     \
+    void Heev(rocblas_handle handle,                                           \
+              rocblas_fill uplo,                                               \
+              rocblas_int n,                                                   \
+              DeviceArray<ScalarType> A,                                       \
+              rocblas_int lda,                                                 \
+              DeviceArray<RealType<ScalarType>> W,                             \
+              DeviceArray<ScalarType> workspace,                               \
+              rocblas_int workspace_size,                                      \
+              DevicePtr<rocblas_int> devinfo)
 
-}// namespace rocsolver
-}// namespace hydrogen
+#define ADD_ROCSOLVER_DECLS(ScalarType)                                        \
+    ADD_POTRF_DECL(ScalarType);                                                \
+    ADD_HEEV_DECL(ScalarType)
+
+ADD_ROCSOLVER_DECLS(float);
+ADD_ROCSOLVER_DECLS(double);
+ADD_ROCSOLVER_DECLS(rocblas_float_complex);
+ADD_ROCSOLVER_DECLS(rocblas_double_complex);
+
+} // namespace rocsolver
+} // namespace hydrogen
 #endif // HYDROGEN_DEVICE_GPU_ROCM_ROCSOLVER_API_HPP_

--- a/src/blas_like/level2/Symv.cpp
+++ b/src/blas_like/level2/Symv.cpp
@@ -56,8 +56,6 @@ void Symv
     }
 }
 
-#if 0 // TOM
-
 template<typename T>
 void Symv
 ( UpperOrLower uplo,
@@ -307,7 +305,6 @@ void LocalRowAccumulate
 
 } // namespace symv
 
-#endif // 0 TOM
 
 #define PROTO(T) \
   template void Symv \
@@ -317,9 +314,7 @@ void LocalRowAccumulate
     const Matrix<T>& x, \
     T beta, \
          Matrix<T>& y, \
-    bool conjugate );
-
-#if 0 // TOM
+    bool conjugate ); \
   template void Symv   \
   ( UpperOrLower uplo, \
     T alpha, \
@@ -347,7 +342,6 @@ void LocalRowAccumulate
           DistMatrix<T,STAR,MC>& z_STAR_MC, \
           DistMatrix<T,STAR,MR>& z_STAR_MR, bool conjugate, \
     const SymvCtrl<T>& ctrl );
-#endif // 0 TOM
 
 #define EL_ENABLE_DOUBLEDOUBLE
 #define EL_ENABLE_QUADDOUBLE

--- a/src/blas_like/level3/CMakeLists.txt
+++ b/src/blas_like/level3/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Add the source files for this directory
 set_full_path(THIS_DIR_SOURCES
   Gemm.cpp
-#  Hemm.cpp
+  Hemm.cpp
 #  Her2k.cpp
   Herk.cpp
 #  HermitianFromEVD.cpp
@@ -10,7 +10,7 @@ set_full_path(THIS_DIR_SOURCES
 #  NormalFromEVD.cpp
 #  QuasiTrsm.cpp
 #  SafeMultiShiftTrsm.cpp
-#  Symm.cpp
+  Symm.cpp
 #  Syr2k.cpp
   Syrk.cpp
 #  Trdtrmm.cpp

--- a/src/blas_like/level3/Hemm.cpp
+++ b/src/blas_like/level3/Hemm.cpp
@@ -2,8 +2,8 @@
    Copyright (c) 2009-2016, Jack Poulson
    All rights reserved.
 
-   This file is part of Elemental and is under the BSD 2-Clause License, 
-   which can be found in the LICENSE file in the root directory, or at 
+   This file is part of Elemental and is under the BSD 2-Clause License,
+   which can be found in the LICENSE file in the root directory, or at
    http://opensource.org/licenses/BSD-2-Clause
 */
 #include <El-lite.hpp>
@@ -45,7 +45,7 @@ void Hemm
 #define EL_ENABLE_QUAD
 #define EL_ENABLE_BIGINT
 #define EL_ENABLE_BIGFLOAT
-#define EL_ENABLE_HALF
+/*#undef EL_ENABLE_HALF*/
 #include <El/macros/Instantiate.h>
 
 } // namespace El

--- a/src/blas_like/level3/Symm.cpp
+++ b/src/blas_like/level3/Symm.cpp
@@ -2,8 +2,8 @@
    Copyright (c) 2009-2016, Jack Poulson
    All rights reserved.
 
-   This file is part of Elemental and is under the BSD 2-Clause License, 
-   which can be found in the LICENSE file in the root directory, or at 
+   This file is part of Elemental and is under the BSD 2-Clause License,
+   which can be found in the LICENSE file in the root directory, or at
    http://opensource.org/licenses/BSD-2-Clause
 */
 #include <El-lite.hpp>
@@ -125,7 +125,7 @@ void Symm
 #define EL_ENABLE_QUAD
 #define EL_ENABLE_BIGINT
 #define EL_ENABLE_BIGFLOAT
-#define EL_ENABLE_HALF
+/*#undef EL_ENABLE_HALF*/
 #include <El/macros/Instantiate.h>
 
 } // namespace El

--- a/src/blas_like/level3/Symm/RL.hpp
+++ b/src/blas_like/level3/Symm/RL.hpp
@@ -2,8 +2,8 @@
    Copyright (c) 2009-2016, Jack Poulson
    All rights reserved.
 
-   This file is part of Elemental and is under the BSD 2-Clause License, 
-   which can be found in the LICENSE file in the root directory, or at 
+   This file is part of Elemental and is under the BSD 2-Clause License,
+   which can be found in the LICENSE file in the root directory, or at
    http://opensource.org/licenses/BSD-2-Clause
 */
 
@@ -66,9 +66,9 @@ void LocalAccumulateRL
 
         auto B1Trans_MR_STAR = BTrans_MR_STAR( ind1, ALL );
 
-        auto Z1Trans_MC_STAR = ZTrans_MC_STAR( ind1, ALL ); 
+        auto Z1Trans_MC_STAR = ZTrans_MC_STAR( ind1, ALL );
         auto Z2Trans_MC_STAR = ZTrans_MC_STAR( ind2, ALL );
-   
+
         auto Z1Trans_MR_STAR = ZTrans_MR_STAR( ind1, ALL );
 
         D11.AlignWith( A11 );
@@ -143,14 +143,14 @@ void RLA
         Zero( Z1Trans_MC_STAR );
         Zero( Z1Trans_MR_STAR );
         LocalAccumulateRL
-        ( orientation, alpha, A, B1_STAR_MC, B1Trans_MR_STAR, 
+        ( orientation, alpha, A, B1_STAR_MC, B1Trans_MR_STAR,
           Z1Trans_MC_STAR, Z1Trans_MR_STAR );
 
         Contract( Z1Trans_MC_STAR, Z1Trans );
         Z1Trans_MR_MC = Z1Trans;
         AxpyContract( T(1), Z1Trans_MR_STAR, Z1Trans_MR_MC );
         Transpose( Z1Trans_MR_MC.LockedMatrix(), Z1Local, conjugate );
-        C1.Matrix() += Z1Local;
+        Axpy( El::To<T>(1), Z1Local, C1.Matrix() );
     }
 }
 

--- a/src/blas_like/level3/Symm/RU.hpp
+++ b/src/blas_like/level3/Symm/RU.hpp
@@ -2,8 +2,8 @@
    Copyright (c) 2009-2016, Jack Poulson
    All rights reserved.
 
-   This file is part of Elemental and is under the BSD 2-Clause License, 
-   which can be found in the LICENSE file in the root directory, or at 
+   This file is part of Elemental and is under the BSD 2-Clause License,
+   which can be found in the LICENSE file in the root directory, or at
    http://opensource.org/licenses/BSD-2-Clause
 */
 
@@ -83,7 +83,7 @@ void LocalAccumulateRU
         ( NORMAL, NORMAL, alpha, D11, B1Trans_MR_STAR, T(1), Z1Trans_MC_STAR );
 
         LocalGemm
-        ( orientation, orientation, 
+        ( orientation, orientation,
           alpha, A12, B1_STAR_MC, T(1), Z2Trans_MR_STAR );
 
         LocalGemm
@@ -143,7 +143,7 @@ void RUA
         Zero( Z1Trans_MC_STAR );
         Zero( Z1Trans_MR_STAR );
         LocalAccumulateRU
-        ( orientation, alpha, A, B1_STAR_MC, B1Trans_MR_STAR, 
+        ( orientation, alpha, A, B1_STAR_MC, B1Trans_MR_STAR,
           Z1Trans_MC_STAR, Z1Trans_MR_STAR );
 
         Contract( Z1Trans_MC_STAR, Z1Trans );
@@ -151,7 +151,7 @@ void RUA
         Z1Trans_MR_MC = Z1Trans;
         AxpyContract( T(1), Z1Trans_MR_STAR, Z1Trans_MR_MC );
         Transpose( Z1Trans_MR_MC.LockedMatrix(), Z1Local, conjugate );
-        C1.Matrix() += Z1Local;
+        Axpy( El::To<T>(1), Z1Local, C1.Matrix() );
     }
 }
 

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -19,7 +19,7 @@ set_full_path(THIS_DIR_SOURCES
 
 # Add the subdirectories
 add_subdirectory(DistMatrix)
-#add_subdirectory(FlamePart)
+add_subdirectory(FlamePart)
 add_subdirectory(imports)
 
 # Propagate the files up the tree

--- a/src/core/FlamePart/CMakeLists.txt
+++ b/src/core/FlamePart/CMakeLists.txt
@@ -1,9 +1,9 @@
 # Add the source files for this directory
 set_full_path(THIS_DIR_SOURCES
-  Merge.cpp
+  # Merge.cpp
   Partition.cpp
-  Repartition.cpp
-  SlidePartition.cpp
+  # Repartition.cpp
+  # SlidePartition.cpp
   )
 
 # Propagate the files up the tree

--- a/src/core/FlamePart/Partition.cpp
+++ b/src/core/FlamePart/Partition.cpp
@@ -2,8 +2,8 @@
    Copyright (c) 2009-2016, Jack Poulson
    All rights reserved.
 
-   This file is part of Elemental and is under the BSD 2-Clause License, 
-   which can be found in the LICENSE file in the root directory, or at 
+   This file is part of Elemental and is under the BSD 2-Clause License,
+   which can be found in the LICENSE file in the root directory, or at
    http://opensource.org/licenses/BSD-2-Clause
 */
 #include <El-lite.hpp>
@@ -15,7 +15,7 @@ namespace El {
 
 template<typename T>
 void PartitionDown
-( Matrix<T>& A, Matrix<T>& AT, Matrix<T>& AB, Int heightAT ) 
+( Matrix<T>& A, Matrix<T>& AT, Matrix<T>& AB, Int heightAT )
 {
     EL_DEBUG_CSE
     heightAT = Max(Min(heightAT,A.Height()),0);
@@ -26,8 +26,8 @@ void PartitionDown
 
 template<typename T>
 void PartitionDown
-( ElementalMatrix<T>& A, 
-  ElementalMatrix<T>& AT, ElementalMatrix<T>& AB, 
+( ElementalMatrix<T>& A,
+  ElementalMatrix<T>& AT, ElementalMatrix<T>& AB,
   Int heightAT )
 {
     EL_DEBUG_CSE
@@ -43,7 +43,7 @@ void PartitionDown
 
 template<typename T>
 void LockedPartitionDown
-( const Matrix<T>& A, Matrix<T>& AT, Matrix<T>& AB, Int heightAT ) 
+( const Matrix<T>& A, Matrix<T>& AT, Matrix<T>& AB, Int heightAT )
 {
     EL_DEBUG_CSE
     heightAT = Max(Min(heightAT,A.Height()),0);
@@ -54,8 +54,8 @@ void LockedPartitionDown
 
 template<typename T>
 void LockedPartitionDown
-( const ElementalMatrix<T>& A, 
-        ElementalMatrix<T>& AT, ElementalMatrix<T>& AB, 
+( const ElementalMatrix<T>& A,
+        ElementalMatrix<T>& AT, ElementalMatrix<T>& AB,
   Int heightAT )
 {
     EL_DEBUG_CSE
@@ -82,8 +82,8 @@ void PartitionUp
 
 template<typename T>
 void PartitionUp
-( ElementalMatrix<T>& A, 
-  ElementalMatrix<T>& AT, ElementalMatrix<T>& AB, 
+( ElementalMatrix<T>& A,
+  ElementalMatrix<T>& AT, ElementalMatrix<T>& AB,
   Int heightAB )
 {
     EL_DEBUG_CSE
@@ -104,8 +104,8 @@ void LockedPartitionUp
 
 template<typename T>
 void LockedPartitionUp
-( const ElementalMatrix<T>& A, 
-        ElementalMatrix<T>& AT, ElementalMatrix<T>& AB, 
+( const ElementalMatrix<T>& A,
+        ElementalMatrix<T>& AT, ElementalMatrix<T>& AB,
   Int heightAB )
 {
     EL_DEBUG_CSE
@@ -132,8 +132,8 @@ void PartitionRight
 
 template<typename T>
 void PartitionRight
-( ElementalMatrix<T>& A, 
-  ElementalMatrix<T>& AL, ElementalMatrix<T>& AR, 
+( ElementalMatrix<T>& A,
+  ElementalMatrix<T>& AL, ElementalMatrix<T>& AR,
   Int widthAL )
 {
     EL_DEBUG_CSE
@@ -160,8 +160,8 @@ void LockedPartitionRight
 
 template<typename T>
 void LockedPartitionRight
-( const ElementalMatrix<T>& A, 
-        ElementalMatrix<T>& AL, ElementalMatrix<T>& AR, 
+( const ElementalMatrix<T>& A,
+        ElementalMatrix<T>& AL, ElementalMatrix<T>& AR,
   Int widthAL )
 {
     EL_DEBUG_CSE
@@ -188,8 +188,8 @@ void PartitionLeft
 
 template<typename T>
 void PartitionLeft
-( ElementalMatrix<T>& A, 
-  ElementalMatrix<T>& AL, ElementalMatrix<T>& AR, 
+( ElementalMatrix<T>& A,
+  ElementalMatrix<T>& AL, ElementalMatrix<T>& AR,
   Int widthAR )
 {
     EL_DEBUG_CSE
@@ -202,7 +202,7 @@ void PartitionLeft
 
 template<typename T>
 void LockedPartitionLeft
-( const Matrix<T>& A, 
+( const Matrix<T>& A,
         Matrix<T>& AL, Matrix<T>& AR, Int widthAR )
 {
     EL_DEBUG_CSE
@@ -211,8 +211,8 @@ void LockedPartitionLeft
 
 template<typename T>
 void LockedPartitionLeft
-( const ElementalMatrix<T>& A, 
-        ElementalMatrix<T>& AL, ElementalMatrix<T>& AR, 
+( const ElementalMatrix<T>& A,
+        ElementalMatrix<T>& AL, ElementalMatrix<T>& AR,
   Int widthAR )
 {
     EL_DEBUG_CSE
@@ -229,7 +229,7 @@ void LockedPartitionLeft
 template<typename T>
 void PartitionDownOffsetDiagonal
 ( Int offset,
-  Matrix<T>& A, 
+  Matrix<T>& A,
   Matrix<T>& ATL, Matrix<T>& ATR,
   Matrix<T>& ABL, Matrix<T>& ABR, Int diagDist )
 {
@@ -238,7 +238,7 @@ void PartitionDownOffsetDiagonal
     const Int n = A.Width();
     const Int diagLength = A.DiagonalLength(offset);
     diagDist = Max(Min(diagDist,diagLength),0);
-    
+
     const Int mCut = ( offset<=0 ? -offset+diagDist : diagDist );
     const Int nCut = ( offset<=0 ? diagDist : offset+diagDist );
     View( ATL, A, 0,    0,    mCut,   nCut   );
@@ -250,9 +250,9 @@ void PartitionDownOffsetDiagonal
 template<typename T>
 void PartitionDownOffsetDiagonal
 ( Int offset,
-  ElementalMatrix<T>& A, 
+  ElementalMatrix<T>& A,
   ElementalMatrix<T>& ATL, ElementalMatrix<T>& ATR,
-  ElementalMatrix<T>& ABL, ElementalMatrix<T>& ABR, 
+  ElementalMatrix<T>& ABL, ElementalMatrix<T>& ABR,
   Int diagDist )
 {
     EL_DEBUG_CSE
@@ -276,7 +276,7 @@ void PartitionDownOffsetDiagonal
 template<typename T>
 void LockedPartitionDownOffsetDiagonal
 ( Int offset,
-  const Matrix<T>& A, 
+  const Matrix<T>& A,
         Matrix<T>& ATL, Matrix<T>& ATR,
         Matrix<T>& ABL, Matrix<T>& ABR, Int diagDist )
 {
@@ -285,7 +285,7 @@ void LockedPartitionDownOffsetDiagonal
     const Int n = A.Width();
     const Int diagLength = A.DiagonalLength(offset);
     diagDist = Max(Min(diagDist,diagLength),0);
-    
+
     const Int mCut = ( offset<=0 ? -offset+diagDist : diagDist );
     const Int nCut = ( offset<=0 ? diagDist : offset+diagDist );
     LockedView( ATL, A, 0,    0,    mCut,   nCut   );
@@ -297,9 +297,9 @@ void LockedPartitionDownOffsetDiagonal
 template<typename T>
 void LockedPartitionDownOffsetDiagonal
 ( Int offset,
-  const ElementalMatrix<T>& A, 
+  const ElementalMatrix<T>& A,
         ElementalMatrix<T>& ATL, ElementalMatrix<T>& ATR,
-        ElementalMatrix<T>& ABL, ElementalMatrix<T>& ABR, 
+        ElementalMatrix<T>& ABL, ElementalMatrix<T>& ABR,
   Int diagDist )
 {
     EL_DEBUG_CSE
@@ -311,7 +311,7 @@ void LockedPartitionDownOffsetDiagonal
     const Int n = A.Width();
     const Int diagLength = A.DiagonalLength(offset);
     diagDist = Max(Min(diagDist,diagLength),0);
-    
+
     const Int mCut = ( offset<=0 ? -offset+diagDist : diagDist );
     const Int nCut = ( offset<=0 ? diagDist : offset+diagDist );
     LockedView( ATL, A, 0,    0,    mCut,   nCut   );
@@ -326,7 +326,7 @@ void LockedPartitionDownOffsetDiagonal
 template<typename T>
 void PartitionUpOffsetDiagonal
 ( Int offset,
-  Matrix<T>& A, 
+  Matrix<T>& A,
   Matrix<T>& ATL, Matrix<T>& ATR,
   Matrix<T>& ABL, Matrix<T>& ABR, Int diagDist )
 {
@@ -338,9 +338,9 @@ void PartitionUpOffsetDiagonal
 template<typename T>
 void PartitionUpOffsetDiagonal
 ( Int offset,
-  ElementalMatrix<T>& A, 
+  ElementalMatrix<T>& A,
   ElementalMatrix<T>& ATL, ElementalMatrix<T>& ATR,
-  ElementalMatrix<T>& ABL, ElementalMatrix<T>& ABR, 
+  ElementalMatrix<T>& ABL, ElementalMatrix<T>& ABR,
   Int diagDist )
 {
     EL_DEBUG_CSE
@@ -355,7 +355,7 @@ void PartitionUpOffsetDiagonal
 template<typename T>
 void LockedPartitionUpOffsetDiagonal
 ( Int offset,
-  const Matrix<T>& A, 
+  const Matrix<T>& A,
         Matrix<T>& ATL, Matrix<T>& ATR,
         Matrix<T>& ABL, Matrix<T>& ABR, Int diagDist )
 {
@@ -367,9 +367,9 @@ void LockedPartitionUpOffsetDiagonal
 template<typename T>
 void LockedPartitionUpOffsetDiagonal
 ( Int offset,
-  const ElementalMatrix<T>& A, 
+  const ElementalMatrix<T>& A,
         ElementalMatrix<T>& ATL, ElementalMatrix<T>& ATR,
-        ElementalMatrix<T>& ABL, ElementalMatrix<T>& ABR, 
+        ElementalMatrix<T>& ABL, ElementalMatrix<T>& ABR,
   Int diagDist )
 {
     EL_DEBUG_CSE
@@ -386,7 +386,7 @@ void LockedPartitionUpOffsetDiagonal
 
 template<typename T>
 void PartitionDownDiagonal
-( Matrix<T>& A, 
+( Matrix<T>& A,
   Matrix<T>& ATL, Matrix<T>& ATR,
   Matrix<T>& ABL, Matrix<T>& ABR, Int diagDist )
 {
@@ -396,9 +396,9 @@ void PartitionDownDiagonal
 
 template<typename T>
 void PartitionDownDiagonal
-( ElementalMatrix<T>& A, 
+( ElementalMatrix<T>& A,
   ElementalMatrix<T>& ATL, ElementalMatrix<T>& ATR,
-  ElementalMatrix<T>& ABL, ElementalMatrix<T>& ABR, 
+  ElementalMatrix<T>& ABL, ElementalMatrix<T>& ABR,
   Int diagDist )
 {
     EL_DEBUG_CSE
@@ -411,7 +411,7 @@ void PartitionDownDiagonal
 
 template<typename T>
 void LockedPartitionDownDiagonal
-( const Matrix<T>& A, 
+( const Matrix<T>& A,
         Matrix<T>& ATL, Matrix<T>& ATR,
         Matrix<T>& ABL, Matrix<T>& ABR, Int diagDist )
 {
@@ -421,9 +421,9 @@ void LockedPartitionDownDiagonal
 
 template<typename T>
 void LockedPartitionDownDiagonal
-( const ElementalMatrix<T>& A, 
+( const ElementalMatrix<T>& A,
         ElementalMatrix<T>& ATL, ElementalMatrix<T>& ATR,
-        ElementalMatrix<T>& ABL, ElementalMatrix<T>& ABR, 
+        ElementalMatrix<T>& ABL, ElementalMatrix<T>& ABR,
   Int diagDist )
 {
     EL_DEBUG_CSE
@@ -439,7 +439,7 @@ void LockedPartitionDownDiagonal
 
 template<typename T>
 void PartitionUpDiagonal
-( Matrix<T>& A, 
+( Matrix<T>& A,
   Matrix<T>& ATL, Matrix<T>& ATR,
   Matrix<T>& ABL, Matrix<T>& ABR, Int diagDist )
 {
@@ -449,9 +449,9 @@ void PartitionUpDiagonal
 
 template<typename T>
 void PartitionUpDiagonal
-( ElementalMatrix<T>& A, 
+( ElementalMatrix<T>& A,
   ElementalMatrix<T>& ATL, ElementalMatrix<T>& ATR,
-  ElementalMatrix<T>& ABL, ElementalMatrix<T>& ABR, 
+  ElementalMatrix<T>& ABL, ElementalMatrix<T>& ABR,
   Int diagDist )
 {
     EL_DEBUG_CSE
@@ -464,7 +464,7 @@ void PartitionUpDiagonal
 
 template<typename T>
 void LockedPartitionUpDiagonal
-( const Matrix<T>& A, 
+( const Matrix<T>& A,
         Matrix<T>& ATL, Matrix<T>& ATR,
         Matrix<T>& ABL, Matrix<T>& ABR, Int diagDist )
 {
@@ -474,9 +474,9 @@ void LockedPartitionUpDiagonal
 
 template<typename T>
 void LockedPartitionUpDiagonal
-( const ElementalMatrix<T>& A, 
+( const ElementalMatrix<T>& A,
         ElementalMatrix<T>& ATL, ElementalMatrix<T>& ATR,
-        ElementalMatrix<T>& ABL, ElementalMatrix<T>& ABR, 
+        ElementalMatrix<T>& ABL, ElementalMatrix<T>& ABR,
   Int diagDist )
 {
     EL_DEBUG_CSE
@@ -493,45 +493,21 @@ void LockedPartitionUpDiagonal
   ( Matrix<T>& A, Matrix<T>& AT, Matrix<T>& AB, Int heightAT ); \
   template void LockedPartitionDown \
   ( const Matrix<T>& A, Matrix<T>& AT, Matrix<T>& AB, Int heightAT ); \
-  template void PartitionDown \
-  ( ElementalMatrix<T>& A, \
-    ElementalMatrix<T>& AT, ElementalMatrix<T>& AB, Int heightAT ); \
-  template void LockedPartitionDown \
-  ( const ElementalMatrix<T>& A, \
-    ElementalMatrix<T>& AT, ElementalMatrix<T>& AB, Int heightAT ); \
   /* Upwards */ \
   template void PartitionUp \
   ( Matrix<T>& A, Matrix<T>& AT, Matrix<T>& AB, Int heightAB ); \
   template void LockedPartitionUp \
   ( const Matrix<T>& A, Matrix<T>& AT, Matrix<T>& AB, Int heightAB ); \
-  template void PartitionUp \
-  ( ElementalMatrix<T>& A, \
-    ElementalMatrix<T>& AT, ElementalMatrix<T>& AB, Int heightAB ); \
-  template void LockedPartitionUp \
-  ( const ElementalMatrix<T>& A, \
-    ElementalMatrix<T>& AT, ElementalMatrix<T>& AB, Int heightAB ); \
   /* Leftward */ \
   template void PartitionLeft \
   ( Matrix<T>& A, Matrix<T>& AL, Matrix<T>& AR, Int widthAR ); \
   template void LockedPartitionLeft \
   ( const Matrix<T>& A, Matrix<T>& AL, Matrix<T>& AR, Int widthAR ); \
-  template void PartitionLeft \
-  ( ElementalMatrix<T>& A, \
-    ElementalMatrix<T>& AL, ElementalMatrix<T>& AR, Int widthAR ); \
-  template void LockedPartitionLeft \
-  ( const ElementalMatrix<T>& A, \
-    ElementalMatrix<T>& AL, ElementalMatrix<T>& AR, Int widthAR ); \
   /* Rightward */ \
   template void PartitionRight \
   ( Matrix<T>& A, Matrix<T>& AL, Matrix<T>& AR, Int widthAL ); \
   template void LockedPartitionRight \
   ( const Matrix<T>& A, Matrix<T>& AL, Matrix<T>& AR, Int widthAL ); \
-  template void PartitionRight \
-  ( ElementalMatrix<T>& A, \
-    ElementalMatrix<T>& AL, ElementalMatrix<T>& AR, Int widthAL ); \
-  template void LockedPartitionRight \
-  ( const ElementalMatrix<T>& A, \
-    ElementalMatrix<T>& AL, ElementalMatrix<T>& AR, Int widthAL ); \
   /* Down the main diagonal */ \
   template void PartitionDownDiagonal \
   ( Matrix<T>& A, \
@@ -541,6 +517,65 @@ void LockedPartitionUpDiagonal
   ( const Matrix<T>& A, \
     Matrix<T>& ATL, Matrix<T>& ATR, \
     Matrix<T>& ABL, Matrix<T>& ABR, Int diagDist ); \
+  /* Down an offset diagonal */ \
+  template void PartitionDownOffsetDiagonal \
+  ( Int offset, Matrix<T>& A, \
+    Matrix<T>& ATL, Matrix<T>& ATR, \
+    Matrix<T>& ABL, Matrix<T>& ABR, Int diagDist ); \
+  template void LockedPartitionDownOffsetDiagonal \
+  ( Int offset, const Matrix<T>& A, \
+    Matrix<T>& ATL, Matrix<T>& ATR, \
+    Matrix<T>& ABL, Matrix<T>& ABR, Int diagDist ); \
+  /* Up the main diagonal */ \
+  template void PartitionUpDiagonal \
+  ( Matrix<T>& A, \
+    Matrix<T>& ATL, Matrix<T>& ATR, \
+    Matrix<T>& ABL, Matrix<T>& ABR, Int diagDist ); \
+  template void LockedPartitionUpDiagonal \
+  ( const Matrix<T>& A, \
+    Matrix<T>& ATL, Matrix<T>& ATR, \
+    Matrix<T>& ABL, Matrix<T>& ABR, Int diagDist ); \
+  /* Up an offset diagonal */ \
+  template void PartitionUpOffsetDiagonal \
+  ( Int offset, Matrix<T>& A, \
+    Matrix<T>& ATL, Matrix<T>& ATR, \
+    Matrix<T>& ABL, Matrix<T>& ABR, Int diagDist ); \
+  template void LockedPartitionUpOffsetDiagonal \
+  ( Int offset, const Matrix<T>& A, \
+    Matrix<T>& ATL, Matrix<T>& ATR, \
+    Matrix<T>& ABL, Matrix<T>& ABR, Int diagDist );
+
+#if 0 // TOM
+#define PROTO(T) \
+  /* Downwards */ \
+  template void PartitionDown \
+  ( ElementalMatrix<T>& A, \
+    ElementalMatrix<T>& AT, ElementalMatrix<T>& AB, Int heightAT ); \
+  template void LockedPartitionDown \
+  ( const ElementalMatrix<T>& A, \
+    ElementalMatrix<T>& AT, ElementalMatrix<T>& AB, Int heightAT ); \
+  /* Upwards */ \
+  template void PartitionUp \
+  ( ElementalMatrix<T>& A, \
+    ElementalMatrix<T>& AT, ElementalMatrix<T>& AB, Int heightAB ); \
+  template void LockedPartitionUp \
+  ( const ElementalMatrix<T>& A, \
+    ElementalMatrix<T>& AT, ElementalMatrix<T>& AB, Int heightAB ); \
+  /* Leftward */ \
+  template void PartitionLeft \
+  ( ElementalMatrix<T>& A, \
+    ElementalMatrix<T>& AL, ElementalMatrix<T>& AR, Int widthAR ); \
+  template void LockedPartitionLeft \
+  ( const ElementalMatrix<T>& A, \
+    ElementalMatrix<T>& AL, ElementalMatrix<T>& AR, Int widthAR ); \
+  /* Rightward */ \
+  template void PartitionRight \
+  ( ElementalMatrix<T>& A, \
+    ElementalMatrix<T>& AL, ElementalMatrix<T>& AR, Int widthAL ); \
+  template void LockedPartitionRight \
+  ( const ElementalMatrix<T>& A, \
+    ElementalMatrix<T>& AL, ElementalMatrix<T>& AR, Int widthAL ); \
+  /* Down the main diagonal */ \
   template void PartitionDownDiagonal \
   ( ElementalMatrix<T>& A, \
     ElementalMatrix<T>& ATL, ElementalMatrix<T>& ATR, \
@@ -551,14 +586,6 @@ void LockedPartitionUpDiagonal
     ElementalMatrix<T>& ABL, ElementalMatrix<T>& ABR, Int diagDist ); \
   /* Down an offset diagonal */ \
   template void PartitionDownOffsetDiagonal \
-  ( Int offset, Matrix<T>& A, \
-    Matrix<T>& ATL, Matrix<T>& ATR, \
-    Matrix<T>& ABL, Matrix<T>& ABR, Int diagDist ); \
-  template void LockedPartitionDownOffsetDiagonal \
-  ( Int offset, const Matrix<T>& A, \
-    Matrix<T>& ATL, Matrix<T>& ATR, \
-    Matrix<T>& ABL, Matrix<T>& ABR, Int diagDist ); \
-  template void PartitionDownOffsetDiagonal \
   ( Int offset, ElementalMatrix<T>& A, \
     ElementalMatrix<T>& ATL, ElementalMatrix<T>& ATR, \
     ElementalMatrix<T>& ABL, ElementalMatrix<T>& ABR, Int diagDist ); \
@@ -567,14 +594,6 @@ void LockedPartitionUpDiagonal
     ElementalMatrix<T>& ATL, ElementalMatrix<T>& ATR, \
     ElementalMatrix<T>& ABL, ElementalMatrix<T>& ABR, Int diagDist ); \
   /* Up the main diagonal */ \
-  template void PartitionUpDiagonal \
-  ( Matrix<T>& A, \
-    Matrix<T>& ATL, Matrix<T>& ATR, \
-    Matrix<T>& ABL, Matrix<T>& ABR, Int diagDist ); \
-  template void LockedPartitionUpDiagonal \
-  ( const Matrix<T>& A, \
-    Matrix<T>& ATL, Matrix<T>& ATR, \
-    Matrix<T>& ABL, Matrix<T>& ABR, Int diagDist ); \
   template void PartitionUpDiagonal \
   ( ElementalMatrix<T>& A, \
     ElementalMatrix<T>& ATL, ElementalMatrix<T>& ATR, \
@@ -585,14 +604,6 @@ void LockedPartitionUpDiagonal
     ElementalMatrix<T>& ABL, ElementalMatrix<T>& ABR, Int diagDist ); \
   /* Up an offset diagonal */ \
   template void PartitionUpOffsetDiagonal \
-  ( Int offset, Matrix<T>& A, \
-    Matrix<T>& ATL, Matrix<T>& ATR, \
-    Matrix<T>& ABL, Matrix<T>& ABR, Int diagDist ); \
-  template void LockedPartitionUpOffsetDiagonal \
-  ( Int offset, const Matrix<T>& A, \
-    Matrix<T>& ATL, Matrix<T>& ATR, \
-    Matrix<T>& ABL, Matrix<T>& ABR, Int diagDist ); \
-  template void PartitionUpOffsetDiagonal \
   ( Int offset, ElementalMatrix<T>& A, \
     ElementalMatrix<T>& ATL, ElementalMatrix<T>& ATR, \
     ElementalMatrix<T>& ABL, ElementalMatrix<T>& ABR, Int diagDist ); \
@@ -600,6 +611,7 @@ void LockedPartitionUpDiagonal
   ( Int offset, const ElementalMatrix<T>& A, \
     ElementalMatrix<T>& ATL, ElementalMatrix<T>& ATR, \
     ElementalMatrix<T>& ABL, ElementalMatrix<T>& ABR, Int diagDist );
+#endif // 0 TOM
 
 #define EL_ENABLE_DOUBLEDOUBLE
 #define EL_ENABLE_QUADDOUBLE

--- a/src/hydrogen/device/cuSOLVER_API.cpp
+++ b/src/hydrogen/device/cuSOLVER_API.cpp
@@ -1,3 +1,4 @@
+#include "hydrogen/device/gpu/cuda/cuSOLVERError.hpp"
 #include <hydrogen/device/gpu/CUDA.hpp>
 #include <hydrogen/device/gpu/cuda/cuSOLVER.hpp>
 
@@ -6,43 +7,145 @@
 
 #include <cusolverDn.h>
 
+// There are some (old, unverified) posts on the interwebs about where
+// exactly performance should fall off. The asymptotics of the Jacobi
+// method aren't as favorable as QR, but for small matrices, it should
+// have some benefit.
+#define CUSOLVER_HEEV_JACOBI_THRESHOLD 1024
+
 namespace hydrogen
 {
 namespace cusolver
 {
 
-#define ADD_POTRF_IMPL(ScalarType, TypeChar)                    \
-    cusolver_int GetPotrfWorkspaceSize(                         \
-        cusolverDnHandle_t handle,                              \
-        cublasFillMode_t uplo,                                  \
-        cusolver_int n,                                         \
-        DeviceArray<ScalarType> A, cusolver_int lda)            \
-    {                                                           \
-        cusolver_int workspace_size;                            \
-        H_CHECK_CUSOLVER(                                       \
-            cusolverDn ## TypeChar ## potrf_bufferSize(         \
-                handle, uplo, n, A, lda, &workspace_size));     \
-        return workspace_size;                                  \
-    }                                                           \
-    void Potrf(                                                 \
-        cusolverDnHandle_t handle,                              \
-        cublasFillMode_t uplo,                                  \
-        cusolver_int n,                                         \
-        DeviceArray<ScalarType> A, cusolver_int lda,            \
-        DeviceArray<ScalarType> workspace,                      \
-        cusolver_int workspace_size,                            \
-        DevicePtr<cusolver_int> devinfo)                        \
-    {                                                           \
-        H_CHECK_CUSOLVER(                                       \
-            cusolverDn ## TypeChar ## potrf(                    \
-                handle, uplo, n, A, lda,                        \
-                workspace, workspace_size, devinfo));           \
+#define ADD_POTRF_IMPL(ScalarType, TypeChar)                                   \
+    cusolver_int GetPotrfWorkspaceSize(cusolverDnHandle_t handle,              \
+                                       cublasFillMode_t uplo,                  \
+                                       cusolver_int n,                         \
+                                       DeviceArray<ScalarType> A,              \
+                                       cusolver_int lda)                       \
+    {                                                                          \
+        cusolver_int workspace_size;                                           \
+        H_CHECK_CUSOLVER(                                                      \
+            cusolverDn##TypeChar##potrf_bufferSize(handle,                     \
+                                                   uplo,                       \
+                                                   n,                          \
+                                                   A,                          \
+                                                   lda,                        \
+                                                   &workspace_size));          \
+        return workspace_size;                                                 \
+    }                                                                          \
+    void Potrf(cusolverDnHandle_t handle,                                      \
+               cublasFillMode_t uplo,                                          \
+               cusolver_int n,                                                 \
+               DeviceArray<ScalarType> A,                                      \
+               cusolver_int lda,                                               \
+               DeviceArray<ScalarType> workspace,                              \
+               cusolver_int workspace_size,                                    \
+               DevicePtr<cusolver_int> devinfo)                                \
+    {                                                                          \
+        H_CHECK_CUSOLVER(cusolverDn##TypeChar##potrf(handle,                   \
+                                                     uplo,                     \
+                                                     n,                        \
+                                                     A,                        \
+                                                     lda,                      \
+                                                     workspace,                \
+                                                     workspace_size,           \
+                                                     devinfo));                \
+    }
+
+syevjInfo_t syevj_params;
+
+#define ADD_HEEV_IMPL(ScalarType, TypePrefix)                                  \
+    cusolver_int GetHeevWorkspaceSize(cusolverDnHandle_t handle,               \
+                                      cublasFillMode_t uplo,                   \
+                                      cusolver_int n,                          \
+                                      DeviceArray<ScalarType> A,               \
+                                      cusolver_int lda,                        \
+                                      DeviceArray<RealType<ScalarType>> W)     \
+    {                                                                          \
+        cusolver_int workspace_size;                                           \
+        if (n < CUSOLVER_HEEV_JACOBI_THRESHOLD)                                \
+        {                                                                      \
+            H_CHECK_CUSOLVER(cusolverDnCreateSyevjInfo(&syevj_params));        \
+            H_CHECK_CUSOLVER(cusolverDn##TypePrefix##evj_bufferSize(           \
+                handle,                                                        \
+                CUSOLVER_EIG_MODE_VECTOR,                                      \
+                uplo,                                                          \
+                n,                                                             \
+                A,                                                             \
+                lda,                                                           \
+                W,                                                             \
+                &workspace_size,                                               \
+                syevj_params));                                                \
+        }                                                                      \
+        else                                                                   \
+        {                                                                      \
+            H_CHECK_CUSOLVER(cusolverDn##TypePrefix##evd_bufferSize(           \
+                handle,                                                        \
+                CUSOLVER_EIG_MODE_VECTOR,                                      \
+                uplo,                                                          \
+                n,                                                             \
+                A,                                                             \
+                lda,                                                           \
+                W,                                                             \
+                &workspace_size));                                             \
+        }                                                                      \
+        return workspace_size;                                                 \
+    }                                                                          \
+    void Heev(cusolverDnHandle_t handle,                                       \
+              cublasFillMode_t uplo,                                           \
+              cusolver_int n,                                                  \
+              DeviceArray<ScalarType> A,                                       \
+              cusolver_int lda,                                                \
+              DeviceArray<RealType<ScalarType>> W,                             \
+              DeviceArray<ScalarType> workspace,                               \
+              cusolver_int workspace_size,                                     \
+              DevicePtr<cusolver_int> devinfo)                                 \
+    {                                                                          \
+        if (n < CUSOLVER_HEEV_JACOBI_THRESHOLD)                                \
+        {                                                                      \
+            H_CHECK_CUSOLVER(                                                  \
+                cusolverDn##TypePrefix##evj(handle,                            \
+                                            CUSOLVER_EIG_MODE_VECTOR,          \
+                                            uplo,                              \
+                                            n,                                 \
+                                            A,                                 \
+                                            lda,                               \
+                                            W,                                 \
+                                            workspace,                         \
+                                            workspace_size,                    \
+                                            devinfo,                           \
+                                            syevj_params));                    \
+                                                                               \
+            H_CHECK_CUSOLVER(                                                  \
+                cusolverDnDestroySyevjInfo(syevj_params));                     \
+        }                                                                      \
+        else                                                                   \
+        {                                                                      \
+            H_CHECK_CUSOLVER(                                                  \
+                cusolverDn##TypePrefix##evd(handle,                            \
+                                            CUSOLVER_EIG_MODE_VECTOR,          \
+                                            uplo,                              \
+                                            n,                                 \
+                                            A,                                 \
+                                            lda,                               \
+                                            W,                                 \
+                                            workspace,                         \
+                                            workspace_size,                    \
+                                            devinfo));                         \
+        }                                                                      \
     }
 
 ADD_POTRF_IMPL(float, S)
 ADD_POTRF_IMPL(double, D)
 ADD_POTRF_IMPL(cuComplex, C)
 ADD_POTRF_IMPL(cuDoubleComplex, Z)
+
+ADD_HEEV_IMPL(float, Ssy)
+ADD_HEEV_IMPL(double, Dsy)
+ADD_HEEV_IMPL(cuComplex, Che)
+ADD_HEEV_IMPL(cuDoubleComplex, Zhe)
 
 } // namespace cusolver
 } // namespace hydrogen

--- a/src/hydrogen/device/rocSOLVER_API.cpp
+++ b/src/hydrogen/device/rocSOLVER_API.cpp
@@ -3,39 +3,74 @@
 
 #include <rocsolver.h>
 
-namespace hydrogen
-{
-namespace rocsolver
-{
+namespace hydrogen {
+namespace rocsolver {
 
-#define ADD_POTRF_IMPL(ScalarType, TypeChar)                    \
-    rocblas_int GetPotrfWorkspaceSize(                          \
-        rocblas_handle /*handle*/,                              \
-        rocblas_fill /*uplo*/,                                  \
-        rocblas_int /*n*/,                                      \
-        DeviceArray<ScalarType> /*A*/, rocblas_int /*lda*/)     \
-    {                                                           \
-        return rocblas_int(0);                                  \
-    }                                                           \
-    void Potrf(                                                 \
-        rocblas_handle handle,                                  \
-        rocblas_fill uplo,                                      \
-        rocblas_int n,                                          \
-        DeviceArray<ScalarType> A, rocblas_int lda,             \
-        DeviceArray<ScalarType> /*workspace*/,                  \
-        rocblas_int /*workspace_size*/,                         \
-        DevicePtr<rocblas_int> devinfo)                         \
-    {                                                           \
-        H_CHECK_ROCSOLVER(                                       \
-            rocsolver_ ## TypeChar ## potrf(                    \
-                handle, uplo, n, A, lda,                        \
-                devinfo));                                      \
+#define ADD_POTRF_IMPL(ScalarType, TypeChar)                                   \
+    rocblas_int GetPotrfWorkspaceSize(rocblas_handle /*handle*/,               \
+                                      rocblas_fill /*uplo*/,                   \
+                                      rocblas_int /*n*/,                       \
+                                      DeviceArray<ScalarType> /*A*/,           \
+                                      rocblas_int /*lda*/)                     \
+    {                                                                          \
+        return rocblas_int(0);                                                 \
+    }                                                                          \
+    void Potrf(rocblas_handle handle,                                          \
+               rocblas_fill uplo,                                              \
+               rocblas_int n,                                                  \
+               DeviceArray<ScalarType> A,                                      \
+               rocblas_int lda,                                                \
+               DeviceArray<ScalarType> /*workspace*/,                          \
+               rocblas_int /*workspace_size*/,                                 \
+               DevicePtr<rocblas_int> devinfo)                                 \
+    {                                                                          \
+        H_CHECK_ROCSOLVER(                                                     \
+            rocsolver_##TypeChar##potrf(handle, uplo, n, A, lda, devinfo));    \
+    }
+
+#define ADD_HEEV_IMPL(ScalarType, TypePrefix)                                  \
+    rocsolver_int GetHeevWorkspaceSize(                                        \
+        rocblas_handle /*handle*/,                                             \
+        rocblas_fill /*uplo*/,                                                 \
+        rocblas_int n,                                                         \
+        DeviceArray<ScalarType> /*A*/,                                         \
+        rocblas_int /*lda*/,                                                   \
+        DeviceArray<RealType<ScalarType>> /*W*/)                               \
+    {                                                                          \
+        return n;                                                              \
+    }                                                                          \
+    void Heev(rocblas_handle handle,                                           \
+              rocblas_fill uplo,                                               \
+              rocblas_int n,                                                   \
+              DeviceArray<ScalarType> A,                                       \
+              rocblas_int lda,                                                 \
+              DeviceArray<RealType<ScalarType>> W,                             \
+              DeviceArray<ScalarType> workspace_in,                            \
+              rocblas_int /*workspace_size*/,                                  \
+              DevicePtr<rocblas_int> devinfo)                                  \
+    {                                                                          \
+        auto* workspace =                                                      \
+            reinterpret_cast<RealType<ScalarType>*>(workspace_in);             \
+        H_CHECK_ROCSOLVER(rocsolver_##TypePrefix##ev(handle,                   \
+                                                     rocblas_evect_original,   \
+                                                     uplo,                     \
+                                                     n,                        \
+                                                     A,                        \
+                                                     lda,                      \
+                                                     W,                        \
+                                                     workspace,                \
+                                                     devinfo));                \
     }
 
 ADD_POTRF_IMPL(float, s)
 ADD_POTRF_IMPL(double, d)
 ADD_POTRF_IMPL(rocblas_float_complex, c)
 ADD_POTRF_IMPL(rocblas_double_complex, z)
+
+ADD_HEEV_IMPL(float, ssy)
+ADD_HEEV_IMPL(double, dsy)
+ADD_HEEV_IMPL(rocblas_float_complex, che)
+ADD_HEEV_IMPL(rocblas_double_complex, zhe)
 
 } // namespace rocsolver
 } // namespace hydrogen

--- a/src/lapack_like/factor/CMakeLists.txt
+++ b/src/lapack_like/factor/CMakeLists.txt
@@ -7,7 +7,7 @@ set_full_path(THIS_DIR_SOURCES
 #  LDL.cpp
 #  LQ.cpp
 #  LU.cpp
-#  QR.cpp
+  QR.cpp
 #  RQ.cpp
 #  Skeleton.cpp
   )
@@ -17,7 +17,7 @@ add_subdirectory(Cholesky)
 #add_subdirectory(LDL)
 #add_subdirectory(LQ)
 #add_subdirectory(LU)
-#add_subdirectory(QR)
+add_subdirectory(QR)
 #add_subdirectory(RQ)
 #add_subdirectory(RegularizedLDL)
 

--- a/src/lapack_like/factor/QR.cpp
+++ b/src/lapack_like/factor/QR.cpp
@@ -102,21 +102,11 @@ void QR
     qr::BusingerGolub( A, householderScalars, signature, Omega, ctrl );
 }
 
-#define PROTO(F) \
-  template void QR \
-  ( Matrix<F>& A, \
-    Matrix<F>& householderScalars, \
-    Matrix<Base<F>>& signature ); \
-  template void QR \
-  ( AbstractDistMatrix<F>& A, \
-    AbstractDistMatrix<F>& householderScalars, \
-    AbstractDistMatrix<Base<F>>& signature ); \
-  template void QR \
-  ( Matrix<F>& A, \
-    Matrix<F>& householderScalars, \
-    Matrix<Base<F>>& signature, \
-    Permutation& Omega, \
-    const QRCtrl<Base<F>>& ctrl ); \
+#if 0 // TOM
+  template void QR
+  ( AbstractDistMatrix<F>& A,
+    AbstractDistMatrix<F>& householderScalars,
+    AbstractDistMatrix<Base<F>>& signature );
   template void QR \
   ( AbstractDistMatrix<F>& A, \
     AbstractDistMatrix<F>& householderScalars, \
@@ -124,27 +114,12 @@ void QR
     DistPermutation& Omega, \
     const QRCtrl<Base<F>>& ctrl ); \
   template void qr::ExplicitTriang \
-  ( Matrix<F>& A, const QRCtrl<Base<F>>& ctrl ); \
-  template void qr::ExplicitTriang \
   ( AbstractDistMatrix<F>& A, const QRCtrl<Base<F>>& ctrl ); \
-  template void qr::ExplicitUnitary \
-  ( Matrix<F>& A, bool thinQR, const QRCtrl<Base<F>>& ctrl ); \
   template void qr::ExplicitUnitary \
   ( AbstractDistMatrix<F>& A, bool thinQR, const QRCtrl<Base<F>>& ctrl ); \
   template void qr::Explicit \
-  ( Matrix<F>& A, \
-    Matrix<F>& R, \
-    bool thinQR, \
-    const QRCtrl<Base<F>>& ctrl ); \
-  template void qr::Explicit \
   ( AbstractDistMatrix<F>& A, \
     AbstractDistMatrix<F>& R, \
-    bool thinQR, \
-    const QRCtrl<Base<F>>& ctrl ); \
-  template void qr::Explicit \
-  ( Matrix<F>& A, \
-    Matrix<F>& R, \
-    Matrix<Int>& Omega, \
     bool thinQR, \
     const QRCtrl<Base<F>>& ctrl ); \
   template void qr::Explicit \
@@ -153,21 +128,6 @@ void QR
     AbstractDistMatrix<Int>& Omega, \
     bool thinQR, \
     const QRCtrl<Base<F>>& ctrl ); \
-  template void qr::NeighborColSwap \
-  (       Matrix<F>& Q, \
-          Matrix<F>& R, \
-    Int j ); \
-  template void qr::DisjointNeighborColSwaps \
-  (       Matrix<F>& Q, \
-          Matrix<F>& R, \
-    const Matrix<Int>& colSwaps ); \
-  template void qr::ApplyQ \
-  ( LeftOrRight side, \
-    Orientation orientation, \
-    const Matrix<F>& A, \
-    const Matrix<F>& householderScalars, \
-    const Matrix<Base<F>>& signature, \
-          Matrix<F>& B ); \
   template void qr::ApplyQ \
   ( LeftOrRight side, \
     Orientation orientation, \
@@ -177,21 +137,11 @@ void QR
           AbstractDistMatrix<F>& B ); \
   template void qr::SolveAfter \
   ( Orientation orientation, \
-    const Matrix<F>& A, \
-    const Matrix<F>& householderScalars, \
-    const Matrix<Base<F>>& signature, \
-    const Matrix<F>& B, \
-          Matrix<F>& X ); \
-  template void qr::SolveAfter \
-  ( Orientation orientation, \
     const AbstractDistMatrix<F>& A, \
     const AbstractDistMatrix<F>& householderScalars, \
     const AbstractDistMatrix<Base<F>>& signature, \
     const AbstractDistMatrix<F>& B, \
           AbstractDistMatrix<F>& X ); \
-  template void qr::Cholesky \
-  ( Matrix<F>& A, \
-    Matrix<F>& R ); \
   template void qr::Cholesky \
   ( AbstractDistMatrix<F>& A, \
     AbstractDistMatrix<F>& R ); \
@@ -207,13 +157,55 @@ void QR
   ( const AbstractDistMatrix<F>& A, TreeData<F>& treeData ); \
   template void qr::ts::Scatter \
   ( AbstractDistMatrix<F>& A, const TreeData<F>& treeData );
+#endif // 0 TOM
+
+#define PROTO(F)                                                               \
+    template void QR(Matrix<F>& A,                                             \
+                     Matrix<F>& householderScalars,                            \
+                     Matrix<Base<F>>& signature);                              \
+    template void QR(Matrix<F>& A,                                             \
+                     Matrix<F>& householderScalars,                            \
+                     Matrix<Base<F>>& signature,                               \
+                     Permutation& Omega,                                       \
+                     const QRCtrl<Base<F>>& ctrl);                             \
+    template void qr::ExplicitTriang(Matrix<F>& A,                             \
+                                     const QRCtrl<Base<F>>& ctrl);             \
+    template void qr::ExplicitUnitary(Matrix<F>& A,                            \
+                                      bool thinQR,                             \
+                                      const QRCtrl<Base<F>>& ctrl);            \
+    template void qr::Explicit(Matrix<F>& A,                                   \
+                               Matrix<F>& R,                                   \
+                               bool thinQR,                                    \
+                               const QRCtrl<Base<F>>& ctrl);                   \
+    template void qr::Explicit(Matrix<F>& A,                                   \
+                               Matrix<F>& R,                                   \
+                               Matrix<Int>& Omega,                             \
+                               bool thinQR,                                    \
+                               const QRCtrl<Base<F>>& ctrl);                   \
+    template void qr::NeighborColSwap(Matrix<F>& Q, Matrix<F>& R, Int j);      \
+    template void qr::DisjointNeighborColSwaps(Matrix<F>& Q,                   \
+                                               Matrix<F>& R,                   \
+                                               const Matrix<Int>& colSwaps);   \
+    template void qr::ApplyQ(LeftOrRight side,                                 \
+                             Orientation orientation,                          \
+                             const Matrix<F>& A,                               \
+                             const Matrix<F>& householderScalars,              \
+                             const Matrix<Base<F>>& signature,                 \
+                             Matrix<F>& B);                                    \
+    template void qr::SolveAfter(Orientation orientation,                      \
+                                 const Matrix<F>& A,                           \
+                                 const Matrix<F>& householderScalars,          \
+                                 const Matrix<Base<F>>& signature,             \
+                                 const Matrix<F>& B,                           \
+                                 Matrix<F>& X);                                \
+    template void qr::Cholesky(Matrix<F>& A, Matrix<F>& R);
 
 #define EL_NO_INT_PROTO
 #define EL_ENABLE_DOUBLEDOUBLE
 #define EL_ENABLE_QUADDOUBLE
 #define EL_ENABLE_QUAD
 #define EL_ENABLE_BIGFLOAT
-#define EL_ENABLE_HALF
+/*#undef EL_ENABLE_HALF*/
 #include <El/macros/Instantiate.h>
 
 } // namespace El

--- a/src/lapack_like/reflect/CMakeLists.txt
+++ b/src/lapack_like/reflect/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Add the source files for this directory
 set_full_path(THIS_DIR_SOURCES
   ApplyPacked.cpp
-  # ExpandPacked.cpp
+  ExpandPacked.cpp
   Householder.cpp
   # Hyperbolic.cpp
   )

--- a/src/lapack_like/reflect/ExpandPacked.cpp
+++ b/src/lapack_like/reflect/ExpandPacked.cpp
@@ -2,8 +2,8 @@
    Copyright (c) 2009-2016, Jack Poulson
    All rights reserved.
 
-   This file is part of Elemental and is under the BSD 2-Clause License, 
-   which can be found in the LICENSE file in the root directory, or at 
+   This file is part of Elemental and is under the BSD 2-Clause License,
+   which can be found in the LICENSE file in the root directory, or at
    http://opensource.org/licenses/BSD-2-Clause
 */
 #include <El.hpp>
@@ -15,7 +15,7 @@
 
 namespace El {
 
-template<typename F> 
+template<typename F>
 void ExpandPackedReflectors
 ( UpperOrLower uplo, VerticalOrHorizontal dir, Conjugation conjugation,
   Int offset,
@@ -30,7 +30,7 @@ void ExpandPackedReflectors
         LogicError("This option is not yet supported");
 }
 
-template<typename F> 
+template<typename F>
 void ExpandPackedReflectors
 ( UpperOrLower uplo, VerticalOrHorizontal dir, Conjugation conjugation,
   Int offset,
@@ -45,17 +45,20 @@ void ExpandPackedReflectors
         LogicError("This option is not yet supported");
 }
 
-#define PROTO(F) \
-  template void ExpandPackedReflectors \
-  ( UpperOrLower uplo, VerticalOrHorizontal dir, Conjugation conjugation, \
-    Int offset, \
-          Matrix<F>& H, \
-    const Matrix<F>& householderScalars ); \
-  template void ExpandPackedReflectors \
-  ( UpperOrLower uplo, VerticalOrHorizontal dir, Conjugation conjugation, \
-    Int offset, \
-          AbstractDistMatrix<F>& H, \
+#define PROTO(F)                                                               \
+    template void ExpandPackedReflectors(UpperOrLower uplo,                    \
+                                         VerticalOrHorizontal dir,             \
+                                         Conjugation conjugation,              \
+                                         Int offset,                           \
+                                         Matrix<F>& H,                         \
+                                         const Matrix<F>& householderScalars);
+#if 0 // TOM
+  template void ExpandPackedReflectors
+  ( UpperOrLower uplo, VerticalOrHorizontal dir, Conjugation conjugation,
+    Int offset,
+          AbstractDistMatrix<F>& H,
     const AbstractDistMatrix<F>& householderScalars );
+#endif // 0 TOM
 
 #define EL_NO_INT_PROTO
 #define EL_ENABLE_DOUBLEDOUBLE

--- a/src/lapack_like/spectral/HermitianEig.cpp
+++ b/src/lapack_like/spectral/HermitianEig.cpp
@@ -269,6 +269,7 @@ HermitianEigInfo Lapack(UpperOrLower uplo,
                         Matrix<Base<F>, El::Device::GPU>& w,
                         const HermitianEigCtrl<F>& ctrl)
 {
+    w.Resize(A.Height(), 1);
     hydrogen::gpu_lapack::HermitianEig(
         UpperOrLowerToFillMode(uplo),
         A.Height(),

--- a/src/lapack_like/spectral/HermitianEig.cpp
+++ b/src/lapack_like/spectral/HermitianEig.cpp
@@ -262,14 +262,31 @@ BlackBox
     return info;
 }
 
+#ifdef HYDROGEN_HAVE_GPU
+template <typename F>
+HermitianEigInfo Lapack(UpperOrLower uplo,
+                        Matrix<F, El::Device::GPU>& A,
+                        Matrix<Base<F>, El::Device::GPU>& w,
+                        const HermitianEigCtrl<F>& ctrl)
+{
+    hydrogen::gpu_lapack::HermitianEig(
+        UpperOrLowerToFillMode(uplo),
+        A.Height(),
+        A.Buffer(),
+        A.LDim(),
+        w.Buffer(),
+        El::SyncInfoFromMatrix(A));
+    return HermitianEigInfo{};
+}
+#endif // HYDROGEN_HAVE_GPU
 } // namespace herm_eig
 
 template<typename F>
 HermitianEigInfo
 HermitianEig
 ( UpperOrLower uplo,
-  Matrix<F>& A,
-  Matrix<Base<F>>& w,
+  Matrix<F, El::Device::CPU>& A,
+  Matrix<Base<F>, El::Device::CPU>& w,
   const HermitianEigCtrl<F>& ctrl )
 {
     EL_DEBUG_CSE
@@ -286,6 +303,26 @@ HermitianEig
     }
     return herm_eig::BlackBox( uplo, A, w, ctrl );
 }
+
+#ifdef HYDROGEN_HAVE_GPU
+// For GPU matrices, the only method is currently LAPACK
+// (cuSOLVER/rocSOLVER).
+template <typename F>
+HermitianEigInfo
+HermitianEig(UpperOrLower uplo,
+             Matrix<F, El::Device::GPU>& A,
+             Matrix<Base<F>, El::Device::GPU>& w,
+             HermitianEigCtrl<F> const& ctrl)
+{
+  EL_DEBUG_CSE
+  if (A.Height() != A.Width())
+      LogicError("Hermitian matrices must be square");
+  if (ctrl.useSDC || ctrl.useScaLAPACK)
+      LogicError("HermitianEig with SDC is not supported.");
+
+  return herm_eig::Lapack(uplo, A, w, ctrl);
+}
+#endif // HYDROGEN_HAVE_GPU
 
 #if 0 // TOM
 
@@ -721,6 +758,24 @@ HermitianEig
     return info;
 }
 
+#ifdef HYDROGEN_HAVE_GPU
+// The "values-only" approach above also always computes the
+// eigenvectors. So we just use that impl and copy them out.
+template <typename F>
+HermitianEigInfo
+HermitianEig(UpperOrLower uplo,
+             Matrix<F, El::Device::GPU>& A,
+             Matrix<Base<F>, El::Device::GPU>& w,
+             Matrix<F, El::Device::GPU>& Q,
+             HermitianEigCtrl<F> const& ctrl)
+{
+    EL_DEBUG_CSE;
+    auto ret = HermitianEig(uplo, A, w, ctrl);
+    Copy(A, Q);
+    return ret;
+}
+#endif // HYDROGEN_HAVE_GPU
+
 #if 0 // TOM
 
 namespace herm_eig {
@@ -1151,12 +1206,12 @@ HermitianEig
 
 #endif // 0 TOM
 
-#define EIGVAL_PROTO(F) \
-  template HermitianEigInfo HermitianEig\
-  ( UpperOrLower uplo, \
-    Matrix<F>& A, \
-    Matrix<Base<F>>& w, \
-    const HermitianEigCtrl<F>& ctrl );
+#define EIGVAL_PROTO_DEVICE(F, D)                                              \
+    template HermitianEigInfo HermitianEig(UpperOrLower uplo,                  \
+                                           Matrix<F, D>& A,                    \
+                                           Matrix<Base<F>, D>& w,              \
+                                           const HermitianEigCtrl<F>& ctrl)
+
 /*
   template HermitianEigInfo HermitianEig\
   ( UpperOrLower uplo, \
@@ -1165,13 +1220,12 @@ HermitianEig
     const HermitianEigCtrl<F>& ctrl );
 */
 
-#define EIGPAIR_PROTO(F) \
-  template HermitianEigInfo HermitianEig\
-  ( UpperOrLower uplo, \
-    Matrix<F>& A, \
-    Matrix<Base<F>>& w, \
-    Matrix<F>& Q,\
-    const HermitianEigCtrl<F>& ctrl );
+#define EIGPAIR_PROTO_DEVICE(F, D)                                             \
+    template HermitianEigInfo HermitianEig(UpperOrLower uplo,                  \
+                                           Matrix<F, D>& A,                    \
+                                           Matrix<Base<F>, D>& w,              \
+                                           Matrix<F, D>& Q,                    \
+                                           const HermitianEigCtrl<F>& ctrl)
 /*
   template HermitianEigInfo HermitianEig      \
   ( UpperOrLower uplo, \
@@ -1181,9 +1235,17 @@ HermitianEig
     const HermitianEigCtrl<F>& ctrl );
 */
 
-#define PROTO(F)                                \
-  EIGVAL_PROTO(F)                               \
-  EIGPAIR_PROTO(F)
+#define PROTO_DEVICE(F, D)                                                     \
+    EIGVAL_PROTO_DEVICE(F, D);                                                 \
+    EIGPAIR_PROTO_DEVICE(F, D)
+
+#ifndef HYDROGEN_HAVE_GPU
+#define PROTO(F) PROTO_DEVICE(F, Device::CPU);
+#else
+#define PROTO(F)                                                               \
+    PROTO_DEVICE(F, Device::CPU);                                              \
+    PROTO_DEVICE(F, Device::GPU);
+#endif
 
 #define EL_NO_INT_PROTO
 #define EL_ENABLE_DOUBLEDOUBLE

--- a/src/matrices/deterministic/CMakeLists.txt
+++ b/src/matrices/deterministic/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Add the subdirectories
 add_subdirectory(classical)
 #add_subdirectory(integral)
-#add_subdirectory(misc)
+add_subdirectory(misc)
 #add_subdirectory(pde)
 #add_subdirectory(sparse_toeplitz)
 

--- a/src/matrices/deterministic/misc/CMakeLists.txt
+++ b/src/matrices/deterministic/misc/CMakeLists.txt
@@ -1,27 +1,27 @@
 # Add the source files for this directory
 set_full_path(THIS_DIR_SOURCES
-  Demmel.cpp
-  DruinskyToledo.cpp
-  DynamicRegCounter.cpp
-  Ehrenfest.cpp
-  ExtendedKahan.cpp
-  GEPPGrowth.cpp
-  GKS.cpp
-  Gear.cpp
-  Hanowa.cpp
-  JordanCholesky.cpp
-  KMS.cpp
-  Kahan.cpp
-  Lauchli.cpp
-  Legendre.cpp
-  Lehmer.cpp
-  Lotkin.cpp
-  MinIJ.cpp
-  Parter.cpp
-  Pei.cpp
-  Redheffer.cpp
-  Riffle.cpp
-  Ris.cpp
+  # Demmel.cpp
+  # DruinskyToledo.cpp
+  # DynamicRegCounter.cpp
+  # Ehrenfest.cpp
+  # ExtendedKahan.cpp
+  # GEPPGrowth.cpp
+  # GKS.cpp
+  # Gear.cpp
+  # Hanowa.cpp
+  # JordanCholesky.cpp
+  # KMS.cpp
+  # Kahan.cpp
+  # Lauchli.cpp
+  # Legendre.cpp
+  # Lehmer.cpp
+  # Lotkin.cpp
+  # MinIJ.cpp
+  # Parter.cpp
+  # Pei.cpp
+  # Redheffer.cpp
+  # Riffle.cpp
+  # Ris.cpp
   Wilkinson.cpp
   )
 

--- a/src/matrices/deterministic/misc/Wilkinson.cpp
+++ b/src/matrices/deterministic/misc/Wilkinson.cpp
@@ -2,8 +2,8 @@
    Copyright (c) 2009-2016, Jack Poulson
    All rights reserved.
 
-   This file is part of Elemental and is under the BSD 2-Clause License, 
-   which can be found in the LICENSE file in the root directory, or at 
+   This file is part of Elemental and is under the BSD 2-Clause License,
+   which can be found in the LICENSE file in the root directory, or at
    http://opensource.org/licenses/BSD-2-Clause
 */
 #include <El-lite.hpp>
@@ -12,7 +12,7 @@
 
 namespace El {
 
-template<typename T> 
+template<typename T>
 void Wilkinson( Matrix<T>& A, Int k )
 {
     EL_DEBUG_CSE
@@ -20,7 +20,7 @@ void Wilkinson( Matrix<T>& A, Int k )
     Zeros( A, n, n );
     FillDiagonal( A, T(1), -1 );
     FillDiagonal( A, T(1),  1 );
-    
+
     for( Int j=0; j<=k; ++j )
         A.Set( j, j, T(k-j) );
     for( Int j=k+1; j<n; ++j )
@@ -35,7 +35,7 @@ void Wilkinson( AbstractDistMatrix<T>& A, Int k )
     Zeros( A, n, n );
     FillDiagonal( A, T(1), -1 );
     FillDiagonal( A, T(1),  1 );
-    
+
     for( Int j=0; j<=k; ++j )
         A.Set( j, j, T(k-j) );
     for( Int j=k+1; j<n; ++j )
@@ -51,7 +51,7 @@ void Wilkinson( AbstractDistMatrix<T>& A, Int k )
 #define EL_ENABLE_QUAD
 #define EL_ENABLE_BIGINT
 #define EL_ENABLE_BIGFLOAT
-#define EL_ENABLE_HALF
+/*#undef EL_ENABLE_HALF*/
 #include <El/macros/Instantiate.h>
 
 } // namespace El

--- a/src/matrices/random/CMakeLists.txt
+++ b/src/matrices/random/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Add the subdirectories
 add_subdirectory(independent)
 add_subdirectory(lattice)
-#add_subdirectory(misc)
+add_subdirectory(misc)
 
 # Propagate the files up the tree
 set(SOURCES "${SOURCES}" "${THIS_DIR_SOURCES}" PARENT_SCOPE)

--- a/src/matrices/random/misc/CMakeLists.txt
+++ b/src/matrices/random/misc/CMakeLists.txt
@@ -1,11 +1,11 @@
 # Add the source files for this directory
 set_full_path(THIS_DIR_SOURCES
   Haar.cpp
-  HatanoNelson.cpp
+  # HatanoNelson.cpp
   HermitianUniformSpectrum.cpp
-  NormalUniformSpectrum.cpp
-  UniformHelmholtzGreens.cpp
-  Wigner.cpp
+  # NormalUniformSpectrum.cpp
+  # UniformHelmholtzGreens.cpp
+  # Wigner.cpp
   )
 
 # Propagate the files up the tree

--- a/src/matrices/random/misc/Haar.cpp
+++ b/src/matrices/random/misc/Haar.cpp
@@ -2,8 +2,8 @@
    Copyright (c) 2009-2016, Jack Poulson
    All rights reserved.
 
-   This file is part of Elemental and is under the BSD 2-Clause License, 
-   which can be found in the LICENSE file in the root directory, or at 
+   This file is part of Elemental and is under the BSD 2-Clause License,
+   which can be found in the LICENSE file in the root directory, or at
    http://opensource.org/licenses/BSD-2-Clause
 */
 #include <El-lite.hpp>
@@ -45,7 +45,7 @@ void Haar( ElementalMatrix<F>& A, Int n )
 template<typename F>
 void ImplicitHaar
 ( ElementalMatrix<F>& A,
-  ElementalMatrix<F>& t, 
+  ElementalMatrix<F>& t,
   ElementalMatrix<Base<F>>& d, Int n )
 {
     EL_DEBUG_CSE
@@ -55,24 +55,29 @@ void ImplicitHaar
     QR( A, t, d );
 }
 
-#define PROTO(F) \
-  template void Haar( Matrix<F>& A, Int n ); \
-  template void Haar( ElementalMatrix<F>& A, Int n ); \
-  template void ImplicitHaar \
-  ( Matrix<F>& A, \
-    Matrix<F>& t, \
-    Matrix<Base<F>>& d, Int n ); \
+#if 0 // TOM
+  template void Haar( Matrix<F>& A, Int n );
+  template void Haar( ElementalMatrix<F>& A, Int n );
+#endif // 0 TOM
+
+#define PROTO(F)                                                               \
+    template void ImplicitHaar(Matrix<F>& A,                                   \
+                               Matrix<F>& t,                                   \
+                               Matrix<Base<F>>& d,                             \
+                               Int n);
+#if 0 // TOM
   template void ImplicitHaar \
   ( ElementalMatrix<F>& A, \
     ElementalMatrix<F>& t, \
     ElementalMatrix<Base<F>>& d, Int n );
+#endif // 0 TOM
 
 #define EL_NO_INT_PROTO
 #define EL_ENABLE_DOUBLEDOUBLE
 #define EL_ENABLE_QUADDOUBLE
 #define EL_ENABLE_QUAD
 #define EL_ENABLE_BIGFLOAT
-#define EL_ENABLE_HALF
+/*#undef EL_ENABLE_HALF*/
 #include <El/macros/Instantiate.h>
 
 } // namespace El

--- a/src/matrices/random/misc/HermitianUniformSpectrum.cpp
+++ b/src/matrices/random/misc/HermitianUniformSpectrum.cpp
@@ -2,10 +2,11 @@
    Copyright (c) 2009-2016, Jack Poulson
    All rights reserved.
 
-   This file is part of Elemental and is under the BSD 2-Clause License, 
-   which can be found in the LICENSE file in the root directory, or at 
+   This file is part of Elemental and is under the BSD 2-Clause License,
+   which can be found in the LICENSE file in the root directory, or at
    http://opensource.org/licenses/BSD-2-Clause
 */
+
 #include <El-lite.hpp>
 #include <El/blas_like/level1.hpp>
 #include <El/lapack_like/factor.hpp>
@@ -42,6 +43,8 @@ void HermitianUniformSpectrum
     MakeDiagonalReal(A);
 }
 
+#if 0 // TOM
+
 template<typename F>
 void HermitianUniformSpectrum
 ( ElementalMatrix<F>& APre, Int n, Base<F> lower, Base<F> upper )
@@ -60,7 +63,7 @@ void HermitianUniformSpectrum
     if( grid.Rank() == 0 )
         for( Int j=0; j<n; ++j )
             d[j] = SampleUniform<Real>( lower, upper );
-    mpi::Broadcast( d.data(), n, 0, grid.Comm() );
+    mpi::Broadcast( d.data(), n, 0, grid.Comm(), SyncInfo<El::Device::CPU>{} );
     Diagonal( A, d );
 
     // Apply a Haar matrix from both sides
@@ -76,19 +79,24 @@ void HermitianUniformSpectrum
     // Force the diagonal to be real-valued
     MakeDiagonalReal(A);
 }
+#endif // TOM 0
 
-#define PROTO(F) \
-  template void HermitianUniformSpectrum \
-  ( Matrix<F>& A, Int n, Base<F> lower, Base<F> upper ); \
+#define PROTO(F)                                                               \
+    template void HermitianUniformSpectrum(Matrix<F>& A,                       \
+                                           Int n,                              \
+                                           Base<F> lower,                      \
+                                           Base<F> upper);
+#if 0 // TOM
   template void HermitianUniformSpectrum \
   ( ElementalMatrix<F>& A, Int n, Base<F> lower, Base<F> upper );
+#endif // TOM 0
 
 #define EL_NO_INT_PROTO
 #define EL_ENABLE_DOUBLEDOUBLE
 #define EL_ENABLE_QUADDOUBLE
 #define EL_ENABLE_QUAD
 #define EL_ENABLE_BIGFLOAT
-#define EL_ENABLE_HALF
+/*#undef EL_ENABLE_HALF*/
 #include <El/macros/Instantiate.h>
 
 } // namespace El

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Add the subdirectories
 add_subdirectory(blas_like)
 add_subdirectory(core)
-#add_subdirectory(lapack_like)
+add_subdirectory(lapack_like)
 
 foreach (src_file ${SOURCES})
 
@@ -19,3 +19,9 @@ foreach (src_file ${SOURCES})
     COMMAND ${MPIEXEC} ${MPIEXEC_NUMPROC_FLAG} 4 ${MPI_PREFLAGS}
     $<TARGET_FILE:${__test_name}> ${MPI_POSTFLAGS})
 endforeach ()
+
+set_target_properties(HermitianEig
+  PROPERTIES
+  CXX_STANDARD 17
+  CXX_EXTENSIONS OFF
+  CXX_STANDARD_REQUIRED TRUE)

--- a/tests/lapack_like/CMakeLists.txt
+++ b/tests/lapack_like/CMakeLists.txt
@@ -1,35 +1,35 @@
 # Add the source files for this directory
 set_full_path(THIS_DIR_SOURCES
-  ApplyPackedReflectors.cpp
-  Bidiag.cpp
-  BidiagDCSVD.cpp
-  Cholesky.cpp
-  CholeskyMod.cpp
-  CholeskyQR.cpp
-  Eig.cpp
+  # ApplyPackedReflectors.cpp
+  # Bidiag.cpp
+  # BidiagDCSVD.cpp
+  # Cholesky.cpp
+  # CholeskyMod.cpp
+  # CholeskyQR.cpp
+  # Eig.cpp
   HermitianEig.cpp
-  HermitianGenDefEig.cpp
-  HermitianTridiag.cpp
-  HermitianTridiagEig.cpp
-  Hessenberg.cpp
-  HessenbergSchur.cpp
-  LDL.cpp
-  LQ.cpp
-  LU.cpp
-  LUMod.cpp
-  MultiShiftHessSolve.cpp
-  QR.cpp
-  RQ.cpp
-  SVD.cpp
-  SVDTwoByTwoUpper.cpp
-  Schur.cpp
-  SchurSwap.cpp
-  SecularEVD.cpp
-  SecularSVD.cpp
-  TSQR.cpp
-  TSSVD.cpp
-  TriangEig.cpp
-  TriangularInverse.cpp
+  # HermitianGenDefEig.cpp
+  # HermitianTridiag.cpp
+  # HermitianTridiagEig.cpp
+  # Hessenberg.cpp
+  # HessenbergSchur.cpp
+  # LDL.cpp
+  # LQ.cpp
+  # LU.cpp
+  # LUMod.cpp
+  # MultiShiftHessSolve.cpp
+  # QR.cpp
+  # RQ.cpp
+  # SVD.cpp
+  # SVDTwoByTwoUpper.cpp
+  # Schur.cpp
+  # SchurSwap.cpp
+  # SecularEVD.cpp
+  # SecularSVD.cpp
+  # TSQR.cpp
+  # TSSVD.cpp
+  # TriangEig.cpp
+  # TriangularInverse.cpp
   )
 
 # Propagate the files up the tree


### PR DESCRIPTION
Both cuSOLVER and rocSOLVER are supported. Always computes eigenvectors, regardless of which `HermitianEig` API is used (use the one without the second matrix (labeled `Q`) to save space and a copy). There is no eigenvalues-only option.

Pinging @aj-prime.