### PR TITLE
Fail fast when LAPACK is not found

### DIFF
--- a/cmake/modules/FindAndVerifyLAPACK.cmake
+++ b/cmake/modules/FindAndVerifyLAPACK.cmake
@@ -171,6 +171,10 @@ else ()
   set(${UPPER_PROJECT_NAME}_HAVE_LAPACK)
 endif ()
 
+if (NOT ${UPPER_PROJECT_NAME}_HAVE_LAPACK)
+  message(FATAL_ERROR "LAPACK support is currently required.")
+endif ()
+
 # Check a few MKL features
 check_function_exists(mkl_dcsrmv ${UPPER_PROJECT_NAME}_HAVE_MKL)
 if (${UPPER_PROJECT_NAME}_HAVE_MKL)


### PR DESCRIPTION
Recent functionality restoration (Cholesky, Eigensolvers) has made LAPACK non-optional. This is a quick patch to fail fast when a suitable LAPACK library is not found. If this affects you, install a LAPACK library.