### PR TITLE
Add debugging annotations to the MemoryPool

### DIFF
--- a/include/El/core/MemoryPool.hpp
+++ b/include/El/core/MemoryPool.hpp
@@ -32,8 +32,23 @@ void ThrowRuntimeError(Args&&... args)
     throw std::runtime_error(oss.str());
 }
 
-/** Returns true iff env(H_MEMPOOL_DEBUG) is truthy. */
+/** @brief Returns true iff env(H_MEMPOOL_DEBUG) is truthy.
+ *
+ *  Truthy values are non-empty strings that start with any character
+ *  other than '0' (ASCII "zero"). So "true", "false", "1", "13",
+ *  "-q", ":)", and " " are all truthy, while "", "0true", "0false",
+ *  "0000", "0123", and "0:)" are all falsey.
+ */
 bool debug_mempool() noexcept;
+
+/** @brief Check env(H_MEMPOOL_BIN_GROWTH). Default 1.6f. */
+float default_mempool_bin_growth() noexcept;
+
+/** @brief Check env(H_MEMPOOL_MIN_BIN). Default 1UL. */
+size_t default_mempool_min_bin() noexcept;
+
+/** @brief Check env(H_MEMPOOL_MAX_BIN). Default (1<<26). */
+size_t default_mempool_max_bin() noexcept;
 
 } // namespace details
 
@@ -58,10 +73,10 @@ public:
      *  @param max_bin_size Largest bin size (in bytes).
      *  @param debug Print debugging messages.
      */
-    MemoryPool(float bin_growth = 1.6,
-               size_t min_bin_size = 1,
-               size_t max_bin_size = 1<<26,
-               bool debug = details::debug_mempool())
+    MemoryPool(float const bin_growth = details::default_mempool_bin_growth(),
+               size_t const min_bin_size = details::default_mempool_min_bin(),
+               size_t const max_bin_size = details::default_mempool_max_bin(),
+               bool const debug = details::debug_mempool())
         : debug_{debug}
     {
         std::set<size_t> bin_sizes;

--- a/include/El/core/MemoryPool.hpp
+++ b/include/El/core/MemoryPool.hpp
@@ -10,6 +10,7 @@
 
 #include <cstddef>
 #include <cstdlib>
+#include <iostream>
 #include <mutex>
 #include <set>
 #include <sstream>
@@ -21,6 +22,7 @@ namespace El
 {
 namespace details
 {
+
 template <typename... Args>
 void ThrowRuntimeError(Args&&... args)
 {
@@ -29,6 +31,10 @@ void ThrowRuntimeError(Args&&... args)
     (void) dummy;
     throw std::runtime_error(oss.str());
 }
+
+/** Returns true iff env(H_MEMPOOL_DEBUG) is truthy. */
+bool debug_mempool() noexcept;
+
 } // namespace details
 
 /** Simple caching memory pool.
@@ -50,10 +56,13 @@ public:
      *  @param bin_growth Controls how fast bins grow.
      *  @param min_bin_size Smallest bin size (in bytes).
      *  @param max_bin_size Largest bin size (in bytes).
+     *  @param debug Print debugging messages.
      */
     MemoryPool(float bin_growth = 1.6,
                size_t min_bin_size = 1,
-               size_t max_bin_size = 1<<26)
+               size_t max_bin_size = 1<<26,
+               bool debug = details::debug_mempool())
+        : debug_{debug}
     {
         std::set<size_t> bin_sizes;
         for (float bin_size = min_bin_size;
@@ -74,23 +83,47 @@ public:
         // Set up bins.
         for (size_t i = 0; i < bin_sizes_.size(); ++i)
             free_data_.emplace_back();
+        if (debug_)
+        {
+            std::clog << "==Mempool(" << this << ")== "
+                      << "Created memory pool ("
+                      << "pinned=" << (Pinned ? "t" : "f")
+                      << ", growth=" << bin_growth
+                      << ", min bin=" << bin_sizes_.front()
+                      << ", max bin=" << bin_sizes_.back() << ")\n"
+                      << "==Mempool(" << this << ")== "
+                      << "Bin sizes: [";
+            for (auto const& b : bin_sizes_)
+                std::clog << " " << b;
+            std::clog << " ]" << std::endl;
+        }
     }
     ~MemoryPool()
     {
         FreeAllUnused();
+        if (debug_)
+            std::clog << "==Mempool(" << this << ")== "
+                      << alloc_to_bin_.size()
+                      << " dangling allocations\n"
+                      << "==Mempool(" << this << ")== "
+                      << "Destroyed memory pool"
+                      << std::endl;
     }
 
     /** Return memory of size bytes. */
     void* Allocate(size_t size)
     {
-        size_t bin = get_bin(size);
+        if (debug_)
+            std::clog << "==Mempool(" << this << ")== "
+                      << "Requesting allocation of "
+                      << size << " bytes."
+                      << std::endl;
+        size_t const bin = get_bin(size);
         void* mem = nullptr;
         std::lock_guard<std::mutex> lock(mutex_);
         // size is too large, this will not be cached.
         if (bin == INVALID_BIN)
-        {
             mem = do_allocation(size);
-        }
         else
         {
             // Check if there is available memory in our bin.
@@ -98,6 +131,10 @@ public:
             {
                 mem = free_data_[bin].back();
                 free_data_[bin].pop_back();
+                --num_cached_blks_;
+                if (debug_)
+                    std::clog << "==Mempool(" << this << ")== "
+                              << "Reusing cached pointer " << mem << "\n";
             }
             else
             {
@@ -105,41 +142,45 @@ public:
             }
         }
         alloc_to_bin_[mem] = bin;
+        if (debug_)
+            std::clog << "==Mempool(" << this << ")== "
+                      << alloc_to_bin_.size()
+                      << " blocks allocated; "
+                      << num_cached_blks_
+                      << " blocks cached"
+                      << std::endl;
+
         return mem;
     }
     /** Release previously allocated memory. */
     void Free(void* ptr)
     {
         std::lock_guard<std::mutex> lock(mutex_);
-        auto iter = alloc_to_bin_.find(ptr);
+        auto const iter = alloc_to_bin_.find(ptr);
         if (iter == alloc_to_bin_.end())
-        {
             details::ThrowRuntimeError("Tried to free unknown ptr");
-        }
+
+        size_t const& bin = iter->second;
+        alloc_to_bin_.erase(iter);
+        if (bin == INVALID_BIN)
+            do_free(ptr);
         else
         {
-            size_t bin = iter->second;
-            alloc_to_bin_.erase(iter);
-            if (bin == INVALID_BIN)
-            {
-                do_free(ptr);
-            }
-            else
-            {
-                // Cache the pointer for reuse.
-                free_data_[bin].push_back(ptr);
-            }
+            // Cache the pointer for reuse.
+            free_data_[bin].push_back(ptr);
+            ++num_cached_blks_;
+            if (debug_)
+                std::clog << "==Mempool(" << this << ")== "
+                          << "Cached pointer " << ptr << "\n";
         }
+        if (debug_)
+            std::clog << "==Mempool(" << this << ")== "
+                      << alloc_to_bin_.size()
+                      << " blocks allocated; "
+                      << num_cached_blks_
+                      << " blocks cached"
+                      << std::endl;
     }
-    /** Release all unused memory. */
-    void FreeAllUnused()
-    {
-        std::lock_guard<std::mutex> lock(mutex_);
-        for (size_t bin = 0; bin < bin_sizes_.size(); ++bin)
-            for (auto&& ptr : free_data_[bin])
-                do_free(ptr);
-    }
-
 private:
 
     /** Index of an invalid bin. */
@@ -157,6 +198,25 @@ private:
     std::vector<std::vector<void*>> free_data_;
     /** Map used pointers to the associated bin index. */
     std::unordered_map<void*, size_t> alloc_to_bin_;
+
+    /** Track the total number of available blocks. */
+    size_t num_cached_blks_;
+
+    /** Print debugging messages throughout lifetime. */
+    bool debug_;
+
+    /** Release all unused memory. */
+    void FreeAllUnused()
+    {
+        std::lock_guard<std::mutex> lock(mutex_);
+        for (size_t bin = 0; bin < bin_sizes_.size(); ++bin)
+        {
+            for (auto&& ptr : free_data_[bin])
+                do_free(ptr);
+            std::vector<void*>{}.swap(free_data_[bin]);
+        }
+        num_cached_blks_ = 0ul;
+    }
 
     /** Allocate size bytes. */
     inline void* do_allocation(size_t size);
@@ -179,7 +239,7 @@ private:
 
 #ifdef HYDROGEN_HAVE_CUDA
 template <>
-inline void* MemoryPool<true>::do_allocation(size_t bytes)
+inline void* MemoryPool<true>::do_allocation(size_t const bytes)
 {
     void* ptr;
     auto error = cudaMallocHost(&ptr, bytes);
@@ -189,11 +249,15 @@ inline void* MemoryPool<true>::do_allocation(size_t bytes)
             "Failed to allocate CUDA pinned memory with message: ",
             "\"", cudaGetErrorString(error), "\"");
     }
+    if (debug_)
+        std::clog << "==Mempool(" << this << ")== "
+                  << "Allocated pinned " << bytes << " bytes at " << ptr
+                  << std::endl;
     return ptr;
 }
 
 template<>
-inline void MemoryPool<true>::do_free(void* ptr)
+inline void MemoryPool<true>::do_free(void* const ptr)
 {
     auto error = cudaFreeHost(ptr);
     if (error != cudaSuccess)
@@ -202,49 +266,64 @@ inline void MemoryPool<true>::do_free(void* ptr)
             "Failed to free CUDA pinned memory with message: ",
             "\"", cudaGetErrorString(error), "\"");
     }
+    if (debug_)
+        std::clog << "==Mempool(" << this << ")== "
+                  << "Freed pinned ptr " << ptr
+                  << std::endl;
 }
 #elif defined(HYDROGEN_HAVE_ROCM)
 template <>
-inline void* MemoryPool<true>::do_allocation(size_t bytes)
+inline void* MemoryPool<true>::do_allocation(size_t const bytes)
 {
     void* ptr;
     auto error = hipHostMalloc(&ptr, bytes);
     if (error != hipSuccess)
-    {
         details::ThrowRuntimeError(
             "Failed to allocate HIP pinned memory with message: ",
             "\"", hipGetErrorString(error), "\"");
-    }
+    if (debug_)
+        std::clog << "==Mempool(" << this << ")== "
+                  << "Allocated pinned " << bytes << " bytes at " << ptr
+                  << std::endl;
     return ptr;
 }
 
 template<>
-inline void MemoryPool<true>::do_free(void* ptr)
+inline void MemoryPool<true>::do_free(void* const ptr)
 {
     auto error = hipHostFree(ptr);
     if (error != hipSuccess)
-    {
         details::ThrowRuntimeError(
             "Failed to free HIP pinned memory with message: ",
             "\"", hipGetErrorString(error), "\"");
-    }
+    if (debug_)
+        std::clog << "==Mempool(" << this << ")== "
+                  << "Freed pinned ptr " << ptr
+                  << std::endl;
 }
 #endif  // HYDROGEN_HAVE_CUDA
 
 template <>
-inline void* MemoryPool<false>::do_allocation(size_t bytes) {
+inline void* MemoryPool<false>::do_allocation(size_t const bytes)
+{
     void* ptr = std::malloc(bytes);
     if (ptr == nullptr)
-    {
         details::ThrowRuntimeError("Failed to allocate memory");
-    }
+    if (debug_)
+        std::clog << "==Mempool(" << this << ")== "
+                  << "Allocated " << bytes << " bytes at " << ptr
+                  << std::endl;
     return ptr;
 }
 
 template<>
-inline void MemoryPool<false>::do_free(void* ptr)
+inline void MemoryPool<false>::do_free(void* const ptr)
 {
-    return std::free(ptr);
+    std::free(ptr);
+    if (debug_)
+        std::clog << "==Mempool(" << this << ")== "
+                  << "Freed ptr " << ptr
+                  << std::endl;
 }
 
 #ifdef HYDROGEN_HAVE_GPU

--- a/src/core/MemoryPool.cpp
+++ b/src/core/MemoryPool.cpp
@@ -4,6 +4,11 @@
 
 namespace El
 {
+bool details::debug_mempool() noexcept
+{
+    char const* const env = std::getenv("H_MEMPOOL_DEBUG");
+    return (env && std::strlen(env) && env[0] != '0');
+}
 
 namespace
 {

--- a/src/core/MemoryPool.cpp
+++ b/src/core/MemoryPool.cpp
@@ -10,6 +10,24 @@ bool details::debug_mempool() noexcept
     return (env && std::strlen(env) && env[0] != '0');
 }
 
+float details::default_mempool_bin_growth() noexcept
+{
+    char const* const env = std::getenv("H_MEMPOOL_BIN_GROWTH");
+    return (env ? std::stof(env) : 1.6);
+}
+
+size_t details::default_mempool_min_bin() noexcept
+{
+    char const* const env = std::getenv("H_MEMPOOL_MIN_BIN");
+    return (env ? std::stoull(env) : 1UL);
+}
+
+size_t details::default_mempool_max_bin() noexcept
+{
+    char const* const env = std::getenv("H_MEMPOOL_MAX_BIN");
+    return (env ? std::stoull(env) : (1 << 26));
+}
+
 namespace
 {
 #ifdef HYDROGEN_HAVE_GPU


### PR DESCRIPTION
Control with `H_MEMPOOL_DEBUG` environment variable.

These roughly match the messages CUB will dump if you turn debugging output on there.