### PR TITLE
Fix half includes for using the one that ships with ROCm

### DIFF
--- a/include/hydrogen/utils/HalfPrecision.hpp
+++ b/include/hydrogen/utils/HalfPrecision.hpp
@@ -46,7 +46,11 @@ struct is_arithmetic<half_float::half> : true_type {};
 #endif
 
 // Now include the actual Half library.
+#if __has_include(<half/half.hpp>) // E.g., the one that ships with ROCm
+#include <half/half.hpp>
+#else
 #include <half.hpp>
+#endif
 
 // Declare the hydrogen typedef
 namespace hydrogen

--- a/include/hydrogen/utils/NumericTypeConversion.hpp
+++ b/include/hydrogen/utils/NumericTypeConversion.hpp
@@ -15,7 +15,11 @@
 */
 
 #ifdef HYDROGEN_HAVE_HALF
+#if __has_include(<half/half.hpp>) // E.g., the one that ships with ROCm
+#include <half/half.hpp>
+#else
 #include <half.hpp>
+#endif
 #endif // HYDROGEN_HAVE_HALF
 
 namespace hydrogen


### PR DESCRIPTION
The regular include works, it just generates "deprecated, use this other file instead" warnings. :/ Everyone's just gotta be different I guess.