### PR TITLE
CUDA 12.2 half fixes

### DIFF
--- a/include/hydrogen/utils/HalfPrecision.hpp
+++ b/include/hydrogen/utils/HalfPrecision.hpp
@@ -103,6 +103,8 @@ inline hydrogen::cpu_half_type operator^(hydrogen::cpu_half_type const&,
 // Grab the right header
 #if defined(HYDROGEN_HAVE_CUDA)
 #include <cuda_fp16.h>
+// Needed for CUDA_VERSION
+#include <cuda.h>
 #elif defined(HYDROGEN_HAVE_ROCM)
 #include <hip/hip_fp16.h>
 #endif // HYDROGEN_HAVE_CUDA
@@ -127,7 +129,7 @@ struct TypeTraits<gpu_half_type>
 
 }// namespace hydrogen
 
-#if defined(HYDROGEN_HAVE_ROCM) || (defined(HYDROGEN_HAVE_CUDA) && !(defined(__CUDACC__)))
+#if defined(HYDROGEN_HAVE_ROCM) || (defined(HYDROGEN_HAVE_CUDA) && !(defined(__CUDACC__)) && (CUDA_VERSION < 12020))
 
 /** @brief Enable "update" functionality for __half. */
 template <typename T>
@@ -237,7 +239,7 @@ inline bool operator!=(
     return !(x == y);
 }
 #endif // defined(HYDROGEN_HAVE_ROCM)
-#endif // defined(HYDROGEN_HAVE_ROCM) || (defined(HYDROGEN_HAVE_CUDA) && !(defined(__CUDACC__)))
+#endif // defined(HYDROGEN_HAVE_ROCM) || (defined(HYDROGEN_HAVE_CUDA) && !(defined(__CUDACC__)) && (CUDA_VERSION < 12020))
 
 inline std::ostream& operator<<(std::ostream& os, hydrogen::gpu_half_type const& x)
 {


### PR DESCRIPTION
CUDA 12.2 now defines host versions of various operator overloads for half, so we should not define them ourselves.