### PR TITLE
[intel MPI] handle quotes in MPI configuration

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -515,7 +515,7 @@ add_subdirectory(src)
 # docs (which has the advantage that preprocessing will take
 # "{,hydrogen_}config.h" into consideration).
 configure_file("${PROJECT_SOURCE_DIR}/cmake/configure_files/config.h.in"
-  "${PROJECT_BINARY_DIR}/include/El/config.h")
+  "${PROJECT_BINARY_DIR}/include/El/config.h" ESCAPE_QUOTES)
 configure_file("${PROJECT_SOURCE_DIR}/cmake/configure_files/hydrogen_config.h.in"
   "${PROJECT_BINARY_DIR}/include/El/hydrogen_config.h")
 configure_file("${PROJECT_SOURCE_DIR}/doxy/Doxyfile.in"


### PR DESCRIPTION
When used with intel mpi, you get a bad config.h because quotes are not handled:
```
#define EL_MPI_CXX_LINK_FLAGS    "-Xlinker --enable-new-dtags -Xlinker -rpath -Xlinker "/localdisk/opt/intel/oneapi/mpi/2021.11/lib"\ -Xlinker -rpath -Xlinker "/localdisk/opt/intel/oneapi/mpi/2021.11/lib" -Xlinker --enable-new-dtags"
```