### PR TITLE
Add Aluminum dispatch for send and recv within TranslateBetweenGrids

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -103,10 +103,6 @@ endif ()
 # Feature-related options
 include(CMakeDependentOption)
 
-option(Hydrogen_ENABLE_ALUMINUM
-  "Enable the Aluminum package for improved device-side communication."
-  OFF)
-
 option(Hydrogen_ENABLE_CUDA
   "Search for CUDA support and enable related features if found."
   OFF)
@@ -393,70 +389,70 @@ if (HYDROGEN_HAVE_CUDA OR HYDROGEN_HAVE_ROCM)
   endif ()
 endif ()
 
-if (Hydrogen_ENABLE_ALUMINUM)
-  find_package(Aluminum 1.0.0 CONFIG QUIET)
+find_package(Aluminum 1.0.0 CONFIG QUIET)
+if (NOT Aluminum_FOUND AND Aluminum_NOT_FOUND_MESSAGE)
+  message(STATUS
+    "A candidate Aluminum > v1.0.0 was found, but was not selected:")
+  message(STATUS
+    "  ${Aluminum_NOT_FOUND_MESSAGE}")
+endif ()
+# Try again, since we're technically ok with >v0.7.0
+if (NOT Aluminum_FOUND)
+  find_package(Aluminum 0.7.0 CONFIG QUIET)
   if (NOT Aluminum_FOUND AND Aluminum_NOT_FOUND_MESSAGE)
     message(STATUS
-      "A candidate Aluminum > v1.0.0 was found, but was not selected:")
+      "A candidate Aluminum > v0.7.0 was found, but was not selected:")
     message(STATUS
       "  ${Aluminum_NOT_FOUND_MESSAGE}")
   endif ()
-  # Try again, since we're technically ok with >v0.7.0
-  if (NOT Aluminum_FOUND)
-    find_package(Aluminum 0.7.0 CONFIG QUIET)
-    if (NOT Aluminum_FOUND AND Aluminum_NOT_FOUND_MESSAGE)
-      message(STATUS
-        "A candidate Aluminum > v0.7.0 was found, but was not selected:")
-      message(STATUS
-        "  ${Aluminum_NOT_FOUND_MESSAGE}")
-    endif ()
+endif ()
+
+if (Aluminum_FOUND)
+  set(HYDROGEN_HAVE_ALUMINUM TRUE)
+  message(STATUS
+    "Found Aluminum@${ALUMINUM_VERSION}: ${Aluminum_DIR}")
+
+  if (HYDROGEN_HAVE_GPU AND AL_HAS_NCCL)
+    set(HYDROGEN_HAVE_NCCL2 TRUE)
+    message(STATUS "Aluminum detected with NCCL2 backend support.")
+  else ()
+    set(HYDROGEN_HAVE_NCCL2 FALSE)
+  endif (HYDROGEN_HAVE_GPU AND AL_HAS_NCCL)
+
+  if (HYDROGEN_HAVE_GPU AND AL_HAS_HOST_TRANSFER)
+    set(HYDROGEN_HAVE_AL_HOST_XFER TRUE)
+    message(STATUS "Aluminum detected with HostTransfer backend support.")
+  else ()
+    set(HYDROGEN_HAVE_AL_HOST_XFER FALSE)
+  endif (HYDROGEN_HAVE_GPU AND AL_HAS_HOST_TRANSFER)
+
+  if (HYDROGEN_HAVE_GPU AND AL_HAS_MPI_CUDA)
+    set(HYDROGEN_HAVE_AL_MPI_CUDA TRUE)
+    message(STATUS "Aluminum detected with MPI-CUDA backend support.")
+  else ()
+    set(HYDROGEN_HAVE_AL_MPI_CUDA FALSE)
+  endif (HYDROGEN_HAVE_GPU AND AL_HAS_MPI_CUDA)
+
+  # Check for in-place SendRecv.
+  if (ALUMINUM_VERSION VERSION_GREATER_EQUAL "1.3.0")
+    set(HYDROGEN_AL_SUPPORTS_INPLACE_SENDRECV TRUE)
+  else ()
+    set(HYDROGEN_AL_SUPPORTS_INPLACE_SENDRECV FALSE)
   endif ()
 
-  if (Aluminum_FOUND)
-    set(HYDROGEN_HAVE_ALUMINUM TRUE)
-    message(STATUS
-      "Found Aluminum@${ALUMINUM_VERSION}: ${Aluminum_DIR}")
-
-    if (HYDROGEN_HAVE_GPU AND AL_HAS_NCCL)
-      set(HYDROGEN_HAVE_NCCL2 TRUE)
-      message(STATUS "Aluminum detected with NCCL2 backend support.")
-    else ()
-      set(HYDROGEN_HAVE_NCCL2 FALSE)
-    endif (HYDROGEN_HAVE_GPU AND AL_HAS_NCCL)
-
-    if (HYDROGEN_HAVE_GPU AND AL_HAS_HOST_TRANSFER)
-      set(HYDROGEN_HAVE_AL_HOST_XFER TRUE)
-      message(STATUS "Aluminum detected with HostTransfer backend support.")
-    else ()
-      set(HYDROGEN_HAVE_AL_HOST_XFER FALSE)
-    endif (HYDROGEN_HAVE_GPU AND AL_HAS_HOST_TRANSFER)
-
-    if (HYDROGEN_HAVE_GPU AND AL_HAS_MPI_CUDA)
-      set(HYDROGEN_HAVE_AL_MPI_CUDA TRUE)
-      message(STATUS "Aluminum detected with MPI-CUDA backend support.")
-    else ()
-      set(HYDROGEN_HAVE_AL_MPI_CUDA FALSE)
-    endif (HYDROGEN_HAVE_GPU AND AL_HAS_MPI_CUDA)
-
-    # Check for in-place SendRecv.
-    if (ALUMINUM_VERSION VERSION_GREATER_EQUAL "1.3.0")
-      set(HYDROGEN_AL_SUPPORTS_INPLACE_SENDRECV TRUE)
-    else ()
-      set(HYDROGEN_AL_SUPPORTS_INPLACE_SENDRECV FALSE)
-    endif ()
-
-    if (HYDROGEN_AL_SUPPORTS_INPLACE_SENDRECV)
-      message(STATUS "Aluminum detected with in-place SendRecv support.")
-    else ()
-      message(STATUS "Aluminum detected WITHOUT in-place SendRecv support.")
-    endif ()
-
+  if (HYDROGEN_AL_SUPPORTS_INPLACE_SENDRECV)
+    message(STATUS "Aluminum detected with in-place SendRecv support.")
   else ()
-    message(FATAL_ERROR "Aluminum support requested but not found. "
-      "Please set Aluminum_DIR to point to the installation prefix "
-      "for Aluminum.")
-  endif (Aluminum_FOUND)
-endif (Hydrogen_ENABLE_ALUMINUM)
+    message(STATUS "Aluminum detected WITHOUT in-place SendRecv support.")
+  endif ()
+
+else ()
+
+  message(FATAL_ERROR "Aluminum support required but not found. "
+    "Please set Aluminum_ROOT to its installation prefix or add "
+    "the installation prefix to CMAKE_PREFIX_PATH.")
+
+endif (Aluminum_FOUND)
 
 # Sets up EL_RESTRICT and EL_HAVE_PRETTY_FUNCTION
 include(detect/CXX)

--- a/include/El/blas_like/level1/Copy/TranslateBetweenGrids.hpp
+++ b/include/El/blas_like/level1/Copy/TranslateBetweenGrids.hpp
@@ -10,71 +10,12 @@
 #define EL_BLAS_COPY_TRANSLATEBETWEENGRIDS_HPP
 
 #include "core/environment/decl.hpp"
+#include <optional>
 
 namespace El
 {
 namespace copy
 {
-namespace internal
-{
-
-inline constexpr auto AlSend = El::Collective::SEND;
-inline constexpr auto AlRecv = El::Collective::RECV;
-
-template <typename T, Device D, El::Collective Op>
-using IsOk = IsAluminumSupported<T, D, Op>;
-
-template <typename T, Device D, El::Collective Op>
-using GetBE = BestBackend<T, D, Op>;
-
-template <typename T, Device D>
-EnableWhen<IsOk<T, D, AlSend>>
-do_send(T const* sbuf,
-             El::Int sc,
-             int to,
-             mpi::Comm const& comm,
-             SyncInfo<D> const& si)
-{
-  using Backend = GetBE<T, D, AlSend>;
-  Al::Send<Backend>(sbuf, sc, to, comm.template GetComm<Backend>(si));
-}
-
-template <typename T, Device D>
-EnableUnless<IsOk<T, D, AlSend>>
-do_send(T const* sbuf,
-        El::Int sc,
-        int to,
-        mpi::Comm const& comm,
-        SyncInfo<D> const& si)
-{
-  mpi::Send(sbuf, sc, to, comm, si);
-}
-
-template <typename T, Device D>
-EnableWhen<IsOk<T, D, AlRecv>>
-do_recv(T* rbuf,
-             El::Int rc,
-             int from,
-             mpi::Comm const& comm,
-             SyncInfo<D> const& si)
-{
-  using Backend = GetBE<T, D, AlRecv>;
-  Al::Recv<Backend>(rbuf, rc, from, comm.template GetComm<Backend>(si));
-}
-
-template <typename T, Device D>
-EnableUnless<IsOk<T, D, AlRecv>>
-do_recv(T* rbuf,
-        El::Int rc,
-        int from,
-        mpi::Comm const& comm,
-        SyncInfo<D> const& si)
-{
-  mpi::Recv(rbuf, rc, from, comm, si);
-}
-
-
-} // namespace internal
 
 template<typename T,Dist U,Dist V,Device D1,Device D2>
 void TranslateBetweenGrids(
@@ -308,13 +249,13 @@ void TranslateBetweenGrids(
           A.LockedBuffer(iLocA,jLocA), numColSends, numRowSends*A.LDim(),
           messageBuf.data(), 1, messageHeight,
           syncInfo);
-        internal::do_send(
+        mpi::Send(
           messageBuf.data(), messageHeight*messageWidth,
           recvViewingRank, viewingCommB, syncInfo);
       }
       else if (viewingRank == recvViewingRank) {
         // Receive data from other rank
-        internal::do_recv(
+        mpi::Recv(
           messageBuf.data(), messageHeight*messageWidth,
           sendViewingRank, viewingCommB, syncInfo);
         copy::util::InterleaveMatrix(
@@ -3623,7 +3564,6 @@ void TranslateBetweenGridsAsync
     const Int mLocA = A.LocalHeight();
     const Int nLocA = A.LocalWidth();
 
-
     mpi::Comm const& viewingCommB = B.Grid().ViewingComm();
     mpi::Group owningGroupA = A.Grid().OwningGroup();
 
@@ -3950,43 +3890,15 @@ void TranslateBetweenGrids(
   Int strideA = A.RowStride();
   Int ALDim = A.LDim();
 
-  // Create A metadata
-  Int recvMetaData[4];
-  Int metaData[4];
-
-  SyncInfo<El::Device::CPU> syncGeneralMetaData = SyncInfo<El::Device::CPU>();
   mpi::Comm const& viewingCommB = B.Grid().ViewingComm();
-
-  const bool inAGrid = A.Participating();
-  const bool inBGrid = B.Participating();
-
-  if(inAGrid)
-  {
-    metaData[0] = m;
-    metaData[1] = n;
-    metaData[2] = strideA;
-    metaData[3] = ALDim;
-  }
-  else
-  {
-    metaData[0] = 0;
-    metaData[1] = 0;
-    metaData[2] = 0;
-    metaData[3] = 0;
-  }
-  const std::vector<Int> sendMetaData (metaData, metaData + 4);
-  mpi::AllReduce( sendMetaData.data(), recvMetaData, 4, mpi::MAX, viewingCommB, syncGeneralMetaData);
-  m = recvMetaData[0];
-  n = recvMetaData[1];
-  strideA = recvMetaData[2];
-  ALDim =recvMetaData[3];
-
 
   B.Resize(m, n);
   const Int nLocA = A.LocalWidth();
   const Int nLocB = B.LocalWidth();
 
   // Return immediately if there is no local data
+  const bool inAGrid = A.Participating();
+  const bool inBGrid = B.Participating();
   if (!inAGrid && !inBGrid) {
     return;
   }
@@ -4000,8 +3912,15 @@ void TranslateBetweenGrids(
   // Synchronize compute streams
   SyncInfo<D> syncInfoA = SyncInfoFromMatrix(A.LockedMatrix());
   SyncInfo<D> syncInfoB = SyncInfoFromMatrix(B.Matrix());
-  auto syncHelper = MakeMultiSync(syncInfoB, syncInfoA);
-  const SyncInfo<D>& syncInfo = syncHelper;
+
+  std::optional<MultiSync<D, D>> maybeMultiSync;
+  if (inAGrid && inBGrid)
+      maybeMultiSync.emplace(syncInfoB, syncInfoA);
+
+  SyncInfo<D> const syncInfo =
+      (maybeMultiSync.has_value()
+       ? *maybeMultiSync
+       : (inAGrid ? syncInfoA : syncInfoB));
 
   // Translate the ranks from A's VC communicator to B's viewing so
   // that we can match send/recv communicators. Since A's VC
@@ -4080,13 +3999,13 @@ void TranslateBetweenGrids(
         A.LockedBuffer(0,jLocA), 1, numSends*ALDim,
         messageBuf.data(), 1, m,
         syncInfo);
-      internal::do_send(
+      mpi::Send(
         messageBuf.data(), m*messageWidth,
         recvViewingRank, viewingCommB, syncInfo);
     }
     else if (viewingRank == recvViewingRank) {
       // Receive data from other rank
-      internal::do_recv(
+      mpi::Recv(
         messageBuf.data(), m*messageWidth,
         sendViewingRank, viewingCommB, syncInfo);
       copy::util::InterleaveMatrix(

--- a/include/El/blas_like/level1/Copy/TranslateBetweenGrids.hpp
+++ b/include/El/blas_like/level1/Copy/TranslateBetweenGrids.hpp
@@ -10,10 +10,71 @@
 #define EL_BLAS_COPY_TRANSLATEBETWEENGRIDS_HPP
 
 #include "core/environment/decl.hpp"
+
 namespace El
 {
 namespace copy
 {
+namespace internal
+{
+
+inline constexpr auto AlSend = El::Collective::SEND;
+inline constexpr auto AlRecv = El::Collective::RECV;
+
+template <typename T, Device D, El::Collective Op>
+using IsOk = IsAluminumSupported<T, D, Op>;
+
+template <typename T, Device D, El::Collective Op>
+using GetBE = BestBackend<T, D, Op>;
+
+template <typename T, Device D>
+EnableWhen<IsOk<T, D, AlSend>>
+do_send(T const* sbuf,
+             El::Int sc,
+             int to,
+             mpi::Comm const& comm,
+             SyncInfo<D> const& si)
+{
+  using Backend = GetBE<T, D, AlSend>;
+  Al::Send<Backend>(sbuf, sc, to, comm.template GetComm<Backend>(si));
+}
+
+template <typename T, Device D>
+EnableUnless<IsOk<T, D, AlSend>>
+do_send(T const* sbuf,
+        El::Int sc,
+        int to,
+        mpi::Comm const& comm,
+        SyncInfo<D> const& si)
+{
+  mpi::Send(sbuf, sc, to, comm, si);
+}
+
+template <typename T, Device D>
+EnableWhen<IsOk<T, D, AlRecv>>
+do_recv(T* rbuf,
+             El::Int rc,
+             int from,
+             mpi::Comm const& comm,
+             SyncInfo<D> const& si)
+{
+  using Backend = GetBE<T, D, AlRecv>;
+  Al::Recv<Backend>(rbuf, rc, from, comm.template GetComm<Backend>(si));
+}
+
+template <typename T, Device D>
+EnableUnless<IsOk<T, D, AlRecv>>
+do_recv(T* rbuf,
+        El::Int rc,
+        int from,
+        mpi::Comm const& comm,
+        SyncInfo<D> const& si)
+{
+  mpi::Recv(rbuf, rc, from, comm, si);
+}
+
+
+} // namespace internal
 
 template<typename T,Dist U,Dist V,Device D1,Device D2>
 void TranslateBetweenGrids(
@@ -247,13 +308,13 @@ void TranslateBetweenGrids(
           A.LockedBuffer(iLocA,jLocA), numColSends, numRowSends*A.LDim(),
           messageBuf.data(), 1, messageHeight,
           syncInfo);
-        mpi::Send(
+        internal::do_send(
           messageBuf.data(), messageHeight*messageWidth,
           recvViewingRank, viewingCommB, syncInfo);
       }
       else if (viewingRank == recvViewingRank) {
         // Receive data from other rank
-        mpi::Recv(
+        internal::do_recv(
           messageBuf.data(), messageHeight*messageWidth,
           sendViewingRank, viewingCommB, syncInfo);
         copy::util::InterleaveMatrix(
@@ -4019,13 +4080,13 @@ void TranslateBetweenGrids(
         A.LockedBuffer(0,jLocA), 1, numSends*ALDim,
         messageBuf.data(), 1, m,
         syncInfo);
-      mpi::Send(
+      internal::do_send(
         messageBuf.data(), m*messageWidth,
         recvViewingRank, viewingCommB, syncInfo);
     }
     else if (viewingRank == recvViewingRank) {
       // Receive data from other rank
-      mpi::Recv(
+      internal::do_recv(
         messageBuf.data(), m*messageWidth,
         sendViewingRank, viewingCommB, syncInfo);
       copy::util::InterleaveMatrix(

--- a/include/El/core/imports/aluminum.hpp
+++ b/include/El/core/imports/aluminum.hpp
@@ -119,8 +119,8 @@ ADD_ALUMINUM_COLLECTIVE(       Collective::REDUCE, Al::MPIBackend);
 ADD_ALUMINUM_COLLECTIVE(Collective::REDUCESCATTER, Al::MPIBackend);
 ADD_ALUMINUM_COLLECTIVE(      Collective::SCATTER, Al::MPIBackend);
 ADD_ALUMINUM_COLLECTIVE(     Collective::SENDRECV, Al::MPIBackend);
-ADD_ALUMINUM_COLLECTIVE(     Collective::SEND, Al::MPIBackend);
-ADD_ALUMINUM_COLLECTIVE(     Collective::RECV, Al::MPIBackend);
+ADD_ALUMINUM_COLLECTIVE(         Collective::SEND, Al::MPIBackend);
+ADD_ALUMINUM_COLLECTIVE(         Collective::RECV, Al::MPIBackend);
 
 #ifdef HYDROGEN_HAVE_NCCL2
 // NCCL backend supports these
@@ -133,8 +133,8 @@ ADD_ALUMINUM_COLLECTIVE(       Collective::REDUCE, Al::NCCLBackend);
 ADD_ALUMINUM_COLLECTIVE(Collective::REDUCESCATTER, Al::NCCLBackend);
 ADD_ALUMINUM_COLLECTIVE(      Collective::SCATTER, Al::NCCLBackend);
 ADD_ALUMINUM_COLLECTIVE(     Collective::SENDRECV, Al::NCCLBackend);
-ADD_ALUMINUM_COLLECTIVE(     Collective::SEND, Al::NCCLBackend);
-ADD_ALUMINUM_COLLECTIVE(     Collective::RECV, Al::NCCLBackend);
+ADD_ALUMINUM_COLLECTIVE(         Collective::SEND, Al::NCCLBackend);
+ADD_ALUMINUM_COLLECTIVE(         Collective::RECV, Al::NCCLBackend);
 #endif // HYDROGEN_HAVE_NCCL2
 
 #ifdef HYDROGEN_HAVE_AL_HOST_XFER
@@ -148,8 +148,8 @@ ADD_ALUMINUM_COLLECTIVE(       Collective::REDUCE, Al::HostTransferBackend);
 ADD_ALUMINUM_COLLECTIVE(Collective::REDUCESCATTER, Al::HostTransferBackend);
 ADD_ALUMINUM_COLLECTIVE(      Collective::SCATTER, Al::HostTransferBackend);
 ADD_ALUMINUM_COLLECTIVE(     Collective::SENDRECV, Al::HostTransferBackend);
-ADD_ALUMINUM_COLLECTIVE(     Collective::SEND, Al::HostTransferBackend);
-ADD_ALUMINUM_COLLECTIVE(     Collective::RECV, Al::HostTransferBackend);
+ADD_ALUMINUM_COLLECTIVE(         Collective::SEND, Al::HostTransferBackend);
+ADD_ALUMINUM_COLLECTIVE(         Collective::RECV, Al::HostTransferBackend);
 #endif // HYDROGEN_HAVE_AL_HOST_XFER
 
 template <Device D>

--- a/include/El/core/imports/aluminum.hpp
+++ b/include/El/core/imports/aluminum.hpp
@@ -31,7 +31,11 @@ enum class Collective
     REDUCE,
     REDUCESCATTER,
     SCATTER,
-    SENDRECV
+    SENDRECV,
+
+    // Not collectives, but what can you do
+    SEND,
+    RECV,
 };// enum class Collective
 
 #ifndef HYDROGEN_HAVE_ALUMINUM
@@ -115,6 +119,8 @@ ADD_ALUMINUM_COLLECTIVE(       Collective::REDUCE, Al::MPIBackend);
 ADD_ALUMINUM_COLLECTIVE(Collective::REDUCESCATTER, Al::MPIBackend);
 ADD_ALUMINUM_COLLECTIVE(      Collective::SCATTER, Al::MPIBackend);
 ADD_ALUMINUM_COLLECTIVE(     Collective::SENDRECV, Al::MPIBackend);
+ADD_ALUMINUM_COLLECTIVE(     Collective::SEND, Al::MPIBackend);
+ADD_ALUMINUM_COLLECTIVE(     Collective::RECV, Al::MPIBackend);
 
 #ifdef HYDROGEN_HAVE_NCCL2
 // NCCL backend supports these
@@ -127,6 +133,8 @@ ADD_ALUMINUM_COLLECTIVE(       Collective::REDUCE, Al::NCCLBackend);
 ADD_ALUMINUM_COLLECTIVE(Collective::REDUCESCATTER, Al::NCCLBackend);
 ADD_ALUMINUM_COLLECTIVE(      Collective::SCATTER, Al::NCCLBackend);
 ADD_ALUMINUM_COLLECTIVE(     Collective::SENDRECV, Al::NCCLBackend);
+ADD_ALUMINUM_COLLECTIVE(     Collective::SEND, Al::NCCLBackend);
+ADD_ALUMINUM_COLLECTIVE(     Collective::RECV, Al::NCCLBackend);
 #endif // HYDROGEN_HAVE_NCCL2
 
 #ifdef HYDROGEN_HAVE_AL_HOST_XFER
@@ -140,6 +148,8 @@ ADD_ALUMINUM_COLLECTIVE(       Collective::REDUCE, Al::HostTransferBackend);
 ADD_ALUMINUM_COLLECTIVE(Collective::REDUCESCATTER, Al::HostTransferBackend);
 ADD_ALUMINUM_COLLECTIVE(      Collective::SCATTER, Al::HostTransferBackend);
 ADD_ALUMINUM_COLLECTIVE(     Collective::SENDRECV, Al::HostTransferBackend);
+ADD_ALUMINUM_COLLECTIVE(     Collective::SEND, Al::HostTransferBackend);
+ADD_ALUMINUM_COLLECTIVE(     Collective::RECV, Al::HostTransferBackend);
 #endif // HYDROGEN_HAVE_AL_HOST_XFER
 
 template <Device D>

--- a/include/El/core/imports/aluminum.hpp
+++ b/include/El/core/imports/aluminum.hpp
@@ -31,9 +31,9 @@ enum class Collective
     REDUCE,
     REDUCESCATTER,
     SCATTER,
-    SENDRECV,
 
     // Not collectives, but what can you do
+    SENDRECV,
     SEND,
     RECV,
 };// enum class Collective

--- a/include/hydrogen/PoolAllocator.hpp
+++ b/include/hydrogen/PoolAllocator.hpp
@@ -584,7 +584,7 @@ struct PooledDeviceAllocator {
         } else {
           const gpuError_t event_status = gpuEventQuery(block_itr->ready_event);
           if (event_status != gpuErrorNotReady) {
-            gpuDebug(event_status);
+            static_cast<void>(gpuDebug(event_status));
             is_reusable = true;
           }
         }
@@ -643,7 +643,7 @@ struct PooledDeviceAllocator {
                  (long long)search_key.associated_stream);
 
         error = gpuSuccess; // Reset the error we will return
-        gpuGetLastError();  // Reset error
+        static_cast<void>(gpuGetLastError());  // Reset error
 
         // Lock
         mutex.lock();
@@ -933,7 +933,7 @@ struct PooledDeviceAllocator {
    */
   virtual ~PooledDeviceAllocator() {
     if (!skip_cleanup)
-      FreeAllCached();
+      static_cast<void>(FreeAllCached());
   }
 
   /* Inspection and reporting methods */


### PR DESCRIPTION
I'm using `TranslateBetweenGrids` as a bit of testbed before wholesale adding these into regular `El::mpi` dispatch as the point-to-point use-cases are a bit more delicate.