### PR TITLE
Remove the 'hipEventDisableSystemFence' flag

### DIFF
--- a/src/hydrogen/device/ROCm.cpp
+++ b/src/hydrogen/device/ROCm.cpp
@@ -75,13 +75,7 @@ hipStream_t GetNewStream()
 hipEvent_t GetNewEvent()
 {
     hipEvent_t event;
-#if HIP_VERSION < 50600000
     H_CHECK_HIP(hipEventCreateWithFlags(&event, hipEventDisableTiming));
-#else
-    H_CHECK_HIP(hipEventCreateWithFlags(
-                    &event,
-                    hipEventDisableTiming | hipEventDisableSystemFence));
-#endif
     return event;
 }
 


### PR DESCRIPTION
Performance implications are not yet understood (do, however, remember we cut out a bunch of superfluous event recording).